### PR TITLE
fix: honor SKIP_Z_CORRECTION in _PICKUP_TOOL

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -444,7 +444,9 @@ gcode:
     {% set svv = printer.save_variables.variables %}
     {% set tool_z = svv["t" ~ t ~ "_offset_z"]|default(0.0)|float %}
     {% set global_z = svv.global_z_offset|default(0.0)|float %}
-    SET_GCODE_OFFSET X={svv["t"~t~"_offset_x"]|default(0.0)} Y={svv["t"~t~"_offset_y"]|default(0.0)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=1
+    {% set skip_z = params.SKIP_Z_CORRECTION|default(0)|int %}
+    {% set apply_z = global_z if skip_z else (tool_z + global_z) %}
+    SET_GCODE_OFFSET X={svv["t"~t~"_offset_x"]|default(0.0)} Y={svv["t"~t~"_offset_y"]|default(0.0)} Z='{"%.3f"|format(apply_z)}' MOVE=1
 
     # Start heating only after tool is fully locked, exited dock, and offsets applied
     {% if params.TARGET|default(0)|float > 0 %}


### PR DESCRIPTION
CHANGE_TOOL already forwards the flag, but _PICKUP_TOOL never reads it.
I've assumed here that the intention is to provide a offset with Z=global_z (which I take to be T0's reference z). 
I may be wrong, but SKIP_Z_CORRECTION should do something regardless, currently it is never accessed.