### PR TITLE
fix: CAL_SET_DOCK_Y may crash every user into tool dock

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -50,10 +50,9 @@
 [gcode_macro CAL_SET_DOCK_Y]
 description: Report the dock_y value for the active tool from current Y position — paste result into indx.cfg
 gcode:
-    {% set tp  = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
     {% if act >= 0 %}
-        {% set new_dock_y = "%.3f"|format(printer.toolhead.position.y|float - tp.trigger_offset|float) %}
+        {% set new_dock_y = "%.3f"|format(printer.toolhead.position.y|float) %}
         RESPOND MSG="──────────────────────────────────────"
         RESPOND MSG="  T{act} dock_y = {new_dock_y}"
         RESPOND MSG="  Update indx.cfg:"


### PR DESCRIPTION
## Summary

`CAL_SET_DOCK_Y` subtracted `trigger_offset` from the jogged seat position, so saved `dock_y` was ~5 mm past the real seat. Park/pickup then moved to that wrong value via `G1 Y{dock_y}` in `_PICKUP_TOOL`, `_PARK_TOOL`, and `_SYNC_UNLOCK_DANCE`.

If a user, as instructed, seats the tool fully, then runs `CAL_SET_DOCK_Y`, the tool will park/pickup overshoot the seat position by ~5 mm into the tool dock. This is likely not optimal.

This PR reports the current Y as `dock_y` when the user jogs to the seated position.

**Before**

```mermaid
%%{init: {'flowchart': {'wrappingWidth': 200}}}%%
flowchart TB
  bSeat["User seats tool<br/>Y = -26"]
  bCal["CAL_SET_DOCK_Y<br/>subtracts trigger_offset"]
  bSaved["indx.cfg<br/>dock_y = -31"]
  bTrig["trigger_y = -26<br/>sprint stops at real seat"]
  bMove["_PICKUP_TOOL / _PARK_TOOL /<br/>_SYNC_UNLOCK_DANCE<br/>G1 Y{dock_y} → Y-31"]
  bBad["5 mm past seat"]

  bSeat --> bCal --> bSaved --> bTrig --> bMove --> bBad
```

**After**

```mermaid
%%{init: {'flowchart': {'wrappingWidth': 200}}}%%
flowchart TB
  aSeat["User seats tool<br/>Y = -26"]
  aCal["CAL_SET_DOCK_Y<br/>reports position.y"]
  aSaved["indx.cfg<br/>dock_y = -26"]
  aTrig["trigger_y = -21<br/>sprint to approach line"]
  aMove["_PICKUP_TOOL / _PARK_TOOL /<br/>_SYNC_UNLOCK_DANCE<br/>G1 Y{dock_y} → Y-26"]
  aGood["Stops at seat"]

  aSeat --> aCal --> aSaved --> aTrig --> aMove --> aGood
```

## Changes

| File                  | What                                                                 |
| --------------------- | -------------------------------------------------------------------- |
| `macros/indx-cal.cfg` | `CAL_SET_DOCK_Y` reports `position.y` as `dock_y`                    |
| `README.md`           | Finding dock_y docs: report is current Y, not Y minus trigger_offset |

## Test plan

- [x] Fresh setup: jog to seated position, run `CAL_SET_DOCK_Y`, confirm reported value matches current Y
- [x] Paste into `indx.cfg`, restart, run `PARK_TOOL` / `T0` - tool seats without overshoot
