### PR TITLE
feat: add dock_dir for rear-mounted tool docks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,8 +1068,11 @@ Before any tool changes can happen, you need to find and save the exact dock pos
 | -------- | ------- |
 | `variable_t{n}_x` | X coordinate of the tool holder centre (mm) |
 | `variable_t{n}_dock_y` | Y coordinate where the tool is fully seated (mm) |
+| `variable_dock_dir` | Y sign into the dock: `-1` front (min Y), `+1` rear (max Y). Default `-1`. |
 
-The trigger line (`dock_y + trigger_offset`) is derived automatically; you only set `dock_y`.
+The trigger line (`dock_y - dock_dir * trigger_offset`) is derived automatically; you only set `dock_y`.
+
+For a rear dock, set `variable_dock_dir: 1` and put `clearance_y` on the bed side of the tools.
 
 > ⚠️ **Take this slow.** Moving the Smart Head into the dock area without verified coordinates is one of the most crash-prone steps in the entire INDX setup. A misaligned approach at speed can damage the Smart Head, the passive tools, or the dock itself.
 >

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -684,7 +684,8 @@ gcode:
 
         M400
         G91
-        G1 Y{-(tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
+        # Use 0- not {- : Jinja treats {- as whitespace strip, so {-(x)} drops the unary minus
+        G1 Y{0 - (tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
         G90
         G1 Y{clear_y} F15000
 

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -684,7 +684,7 @@ gcode:
 
         M400
         G91
-        G1 Y{c.peel_distance} F{c.peel_feedrate}
+        G1 Y{-(tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
         G90
         G1 Y{clear_y} F15000
 

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -208,7 +208,8 @@ gcode:
 
     # 1. Gentle peel off the docking pins (relative move)
     G91
-    G1 Y{-(tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
+    # Use 0- not {- : Jinja treats {- as whitespace strip, so {-(x)} drops the unary minus
+    G1 Y{0 - (tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
 
     # 2. High-speed sprint to the clearance line (absolute move).
     #    When RESTORE_Z is set (pickup exit), fold the Z hop-down into this move

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -6,7 +6,7 @@
 #  mesh. DO NOT MODIFY unless you are changing the physical hardware.
 #
 #  Per-tool positions are derived as:
-#     trigger_y   = tool.dock_y + TOOL_POSITIONS.trigger_offset  (set in indx.cfg)
+#     trigger_y   = tool.dock_y - TOOL_POSITIONS.dock_dir * trigger_offset
 #     clearance_y = TOOL_POSITIONS.clearance_y                   (set in indx.cfg)
 #
 #####################################################################
@@ -18,9 +18,9 @@ description: Fixed INDX hardware constants — do not modify
 # Distance for the gentle peel-off after parking/pickup (relative move)
 variable_peel_distance: 10.0
 
-# --- Unlock dance: Y depths below trigger_y ---
+# --- Unlock dance: Y depths toward the dock from trigger_y ---
 # These define the waypoints of the wiggle sequence.
-# Expressed as positive distances below trigger_y.
+# Expressed as positive distances along dock_dir from trigger_y.
 variable_squeeze_depth: 0.5
 variable_wiggle_in_depth: 1.0
 variable_wiggle_out_depth: 2.0
@@ -208,7 +208,7 @@ gcode:
 
     # 1. Gentle peel off the docking pins (relative move)
     G91
-    G1 Y{c.peel_distance} F{c.peel_feedrate}
+    G1 Y{-(tp.dock_dir * c.peel_distance)} F{c.peel_feedrate}
 
     # 2. High-speed sprint to the clearance line (absolute move).
     #    When RESTORE_Z is set (pickup exit), fold the Z hop-down into this move
@@ -230,7 +230,7 @@ gcode:
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
     {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set dock_y = params.DOCK_Y|float %}
-    {% set trigger_y = dock_y + tp.trigger_offset %}
+    {% set trigger_y = dock_y - tp.dock_dir * tp.trigger_offset %}
 
     # Latch (E) moves run through INDX_EXTRUDER_MOVE so they work cold, with no
     # need to heat the tool. INDX_EXTRUDER_MOVE is E-only and waits for motion
@@ -241,13 +241,13 @@ gcode:
 
     # 1. Squeeze release (soft current)
     _TC_LATCH_MOVE E={c.squeeze_e} F={c.squeeze_feedrate} I={c.squeeze_current}
-    G1 Y{"%.3f"|format(trigger_y - c.squeeze_depth)} F{c.squeeze_feedrate}
+    G1 Y{"%.3f"|format(trigger_y + tp.dock_dir * c.squeeze_depth)} F{c.squeeze_feedrate}
 
     # 2. Wiggle In → Wiggle Out → Dock (latch nudge first, then Y approach)
     _TC_LATCH_MOVE E={c.wiggle_in_e} F={c.squeeze_feedrate} I={c.run_current}
-    G1 Y{"%.3f"|format(trigger_y - c.wiggle_in_depth)} F{c.squeeze_feedrate}
+    G1 Y{"%.3f"|format(trigger_y + tp.dock_dir * c.wiggle_in_depth)} F{c.squeeze_feedrate}
     _TC_LATCH_MOVE E={c.wiggle_out_e} F={c.wiggle_feedrate} I={c.run_current}
-    G1 Y{"%.3f"|format(trigger_y - c.wiggle_out_depth)} F{c.wiggle_feedrate}
+    G1 Y{"%.3f"|format(trigger_y + tp.dock_dir * c.wiggle_out_depth)} F{c.wiggle_feedrate}
     G1 Y{"%.3f"|format(dock_y)} F{c.dock_feedrate}
 
     # 3. Final stationary open
@@ -360,7 +360,7 @@ gcode:
         # Resolve this tool's dock geometry
         {% set tool = tp.tools[act] %}
         {% set dock_y = tool.dock_y %}
-        {% set trigger_y = dock_y + tp.trigger_offset %}
+        {% set trigger_y = dock_y - tp.dock_dir * tp.trigger_offset %}
 
         {% set clearance_y = tp.clearance_y %}
 
@@ -398,7 +398,7 @@ gcode:
     # Resolve this tool's dock geometry
     {% set tool = tp.tools[t] %}
     {% set dock_y = tool.dock_y %}
-    {% set trigger_y = dock_y + tp.trigger_offset %}
+    {% set trigger_y = dock_y - tp.dock_dir * tp.trigger_offset %}
 
     {% set clearance_y = tp.clearance_y %}
 

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -11,13 +11,13 @@
 #    Then fill in one pair of variables per tool (tN_x, tN_dock_y).
 #       x      — X coordinate centred on the tool holder (mm)
 #       dock_y — Y coordinate where the tool is fully seated (mm)
-#                (tools with larger bodies may need a more negative value)
+#                (deeper into the dock along dock_dir)
 #
 #    Tool number = variable suffix.  t0 = T0, t1 = T1, etc.
 #    Add or remove pairs and update tool_count — the system adapts automatically.
 #
 #  WHAT IS AUTO-DERIVED:
-#    - Trigger Y per tool (dock_y + trigger_offset)
+#    - Trigger Y per tool (dock_y - dock_dir * trigger_offset)
 #
 #  WHAT NOT TO TOUCH:
 #    - E-axis moves and dance geometry are fixed hardware constants
@@ -54,9 +54,14 @@ variable_probe_y:          -1.0   # set to bed centre Y, or -1 to auto-detect
 variable_probe_fuzz:         2.0
 variable_probe_z_clearance: 10.0
 
+# ── Dock approach direction ──────────────────────────────────────────────────
+#  dock_dir = Y sign into the dock: -1 front (min Y), +1 rear (max Y).
+#             Flips trigger line, unlock depths, and peel relative to dock_y.
+variable_dock_dir: -1
+
 # ── Trigger offset ───────────────────────────────────────────────────────────
 #  trigger_offset = distance (mm) from dock_y to the trigger line.
-#                   trigger_y is auto-derived as: dock_y + trigger_offset
+#                   trigger_y is auto-derived as: dock_y - dock_dir * trigger_offset
 #                   Increase if the latch engages before the tool is fully seated;
 #                   decrease if the toolhead overshoots the dock.
 variable_trigger_offset: 5.0
@@ -70,7 +75,7 @@ variable_clearance_y: 0.0
 # ── Per-tool positions ────────────────────────────────────────────────────────
 #  x      = X coordinate of the tool holder centre (mm)
 #  dock_y = Y coordinate where the tool is fully seated (mm)
-#           A more negative value seats the tool deeper.
+#           Move further along dock_dir to seat the tool deeper.
 #
 #  To add a tool:    add a new pair of lines and increment tool_count above.
 #  To remove a tool: delete its pair of lines and decrement tool_count above.


### PR DESCRIPTION
# feat: add dock_dir for rear-mounted tool docks

## Summary

Dock geometry assumed the tools sit at the front of the machine (min Y). `trigger_y`, unlock-dance depths, and peel-off moves all used that sign. On a rear-mounted dock (max Y), park/pickup approached from the wrong side and could drive past the seat into the dock.

Adds `variable_dock_dir` (`-1` front, `+1` rear, default `-1`) for trigger-line derivation, unlock dance, and peel moves. Default `-1` leaves existing front-dock configs alone.

## Alternative

To avoid another variable, derive `dock_dir` from `clearance_y` and a tool's `dock_y`: the sign of Y that moves from `clearance_y` toward `dock_y` (i.e. `sign(dock_y - clearance_y)`).

## Changes

| File | What |
| ---- | ---- |
| `macros/indx.cfg` | Add `variable_dock_dir: -1`; update trigger-line comments |
| `macros/indx-tc-macros.cfg` | Derive `trigger_y`, unlock dance, and peel from `dock_dir` |
| `macros/indx-cal.cfg` | Peel direction in dock calibration uses `dock_dir` |
| `README.md` | Document `variable_dock_dir` and rear-dock `clearance_y` placement |

## Test plan

- [x] Front dock (`dock_dir: -1`, default): `PARK_TOOL` / `T0` matches current behaviour
- [x] Rear dock (`dock_dir: 1`): same behaiour but in reverse direction.
- [x] Rear dock: peel-off after park moves away from the dock (toward `clearance_y` on the bed side)
