### PR TITLE
fix: macros - require TOOL= on CHANGE_TOOL

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -261,8 +261,10 @@ gcode:
 
 [gcode_macro CHANGE_TOOL]
 gcode:
-    {% if "TOOL" in params %}
-        {% set t = params.TOOL|int %}
+    {% if 'TOOL' not in params %}
+        {action_raise_error("CHANGE_TOOL requires TOOL=<n> (or use T0/T1/...).")}
+    {% endif %}
+    {% set t = params.TOOL|int %}
         {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
         {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
 
@@ -338,7 +340,6 @@ gcode:
             # 9. Restore live slicer motion limits so the print resumes correctly
             SET_VELOCITY_LIMIT VELOCITY={live_vel} ACCEL={live_acc}
         {% endif %}
-    {% endif %}
 
 [gcode_macro PARK_TOOL]
 gcode:


### PR DESCRIPTION
## Summary

`CHANGE_TOOL` with no `TOOL=` was a silent no-op. Early guard now raises an error (same pattern as `LOAD_FILAMENT`).

## Test plan

- [x] `CHANGE_TOOL` → error
- [x] `CHANGE_TOOL SKIP_Z_CORRECTION=1` (no TOOL) → error
- [x] `T0` / `CHANGE_TOOL TOOL=0` → unchanged