### PR TITLE
fix: _CAL_GOTO_CAMPOS - remove default move to X0 Y0 Z0

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -121,14 +121,20 @@ gcode:
 [gcode_macro _CAL_GOTO_CAMPOS]
 description: Inner — move to saved camera reference position
 gcode:
-    {% set svv    = printer.save_variables.variables %}
-    {% set safe_z = svv.cam_pos_z|default(10)|float + 5.0 %}
+    {% set svv = printer.save_variables.variables %}
+    {% if 'cam_pos_x' not in svv or 'cam_pos_y' not in svv or 'cam_pos_z' not in svv %}
+        {action_raise_error("Camera reference missing. Run CAL_01_SET_CAMERA_REF first.")}
+    {% endif %}
+    {% set cx = svv.cam_pos_x|float %}
+    {% set cy = svv.cam_pos_y|float %}
+    {% set cz = svv.cam_pos_z|float %}
+    {% set safe_z = cz + 5.0 %}
     G90
     {% if printer.toolhead.position.z < safe_z %}
         G0 Z{safe_z} F1500
     {% endif %}
-    G0 X{svv.cam_pos_x|default(0)|float} Y{svv.cam_pos_y|default(0)|float} F8000
-    G0 Z{svv.cam_pos_z|default(0)|float} F1500
+    G0 X{cx} Y{cy} F8000
+    G0 Z{cz} F1500
 
 
 #####################################################################


### PR DESCRIPTION
# fix: _CAL_GOTO_CAMPOS - remove default move to X0 Y0 Z0

## Issue

Missing `cam_pos_*` fell back to X0 Y0 Z0. The safe-Z lift used `cam_pos_z|default(10)`, but the final move used `cam_pos_z|default(0)`, so any clearance was cancelled by a rapid plunge to the bed. If a user had a camera near that location, or tool docks, these would be hit.

## Summary
If the position variables are not set, it is an error state as it means the user has not followed the correct procedure.

`_CAL_GOTO_CAMPOS` no longer defaults missing `cam_pos_*` to origin/Z0 — it errors until `CAL_01_SET_CAMERA_REF` has run, so the safe-Z lift can't be cancelled by a plunge to Z0.