### PR TITLE
fix: require TOOL= on dock X calibration macros

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -594,7 +594,10 @@ gcode:
 description: Measure absolute dock X for TOOL=n via INDX_DOCK_MEASURE. Run after M84 + manual slide to dock.
 variable_tool: 0
 gcode:
-    {% set t = params.TOOL|default(0)|int %}
+    {% if 'TOOL' not in params %}
+        {action_raise_error("CALIBRATE_DOCK_X requires TOOL=<n>")}
+    {% endif %}
+    {% set t = params.TOOL|int %}
     SET_GCODE_VARIABLE MACRO=CALIBRATE_DOCK_X VARIABLE=tool VALUE={t}
     RESPOND MSG="──────────────────────────────────────────────"
     RESPOND MSG="  CALIBRATE_DOCK_X  T{t}"
@@ -628,7 +631,10 @@ gcode:
 [gcode_macro READ_DOCK_POSITION]
 description: Save current (already-homed) X as dock X for TOOL=n. Home first, jog to the dock, then run.
 gcode:
-    {% set t = params.TOOL|default(0)|int %}
+    {% if 'TOOL' not in params %}
+        {action_raise_error("READ_DOCK_POSITION requires TOOL=<n>")}
+    {% endif %}
+    {% set t = params.TOOL|int %}
     {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}
         RESPOND TYPE=error MSG="READ_DOCK_POSITION: home the printer (G28) first, or use CALIBRATE_DOCK_X."
     {% else %}


### PR DESCRIPTION
# fix: require TOOL= on dock X calibration macros

## Issue

`READ_DOCK_POSITION` and `CALIBRATE_DOCK_X` use `params.TOOL|default(0)`. Docs always pass `TOOL=N`. A silent T0 default can mislabel which tool was measured.

If someone pastes this into `indx.cfg`, they can end up with confusing issues around having duplicate T0 entries and missing entries for tools they thought they just pasted in.

## Summary

Require `TOOL=` on both macros (same pattern as `CHANGE_TOOL` / `LOAD_FILAMENT`). Drop `|default(0)`.