### PR TITLE
fix: CAL_Z unreachable and likely (certain?) to damage hardware

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -539,10 +539,15 @@ gcode:
 description: Inner — compute Z offsets from median results and save
 gcode:
     {% set svv    = printer.save_variables.variables %}
+    {% set cfg    = printer["gcode_macro CAL_Z"] %}
     {% set n      = svv.v2z_total_tools|int %}
     {% set ref_z  = svv.v2z_result_0|float %}
     {% set t0_off = svv.t0_offset_z|default(0.0)|float %}
 
+    # Same lift as _CZ_NEXT_TOOL
+    {% set tc_z = [printer.toolhead.position.z, cfg.toolchange_z|float]|max %}
+    G90
+    G0 Z{'%.3f'|format(tc_z)} F3000
     PARK_TOOL
 
     RESPOND MSG="═══════════════════════════════════════════════"

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -213,7 +213,7 @@ gcode:
 
     RESPOND MSG="═══════════════════════════════════════════════"
     RESPOND MSG="  CAL_Z — {n} tools"
-    RESPOND MSG="  T0 reference offset: {svv.t0_offset_z}"
+    RESPOND MSG="  T0 reference offset: {svv.t0_offset_z|default(0.0)}"
     RESPOND MSG="  Location       {loc}  (inset {'%.1f'|format(ins)} mm)"
     RESPOND MSG="  Clean probe    X={'%.2f'|format(pns.cx)}  Y={'%.2f'|format(pns.cy)}"
     RESPOND MSG="  Convergence    SD < 0.005 mm over 4-sample window  (fuzz after 7)"
@@ -541,7 +541,7 @@ gcode:
     {% set svv    = printer.save_variables.variables %}
     {% set n      = svv.v2z_total_tools|int %}
     {% set ref_z  = svv.v2z_result_0|float %}
-    {% set t0_off = svv.t0_offset_z|float %}
+    {% set t0_off = svv.t0_offset_z|default(0.0)|float %}
 
     PARK_TOOL
 


### PR DESCRIPTION
## Issue - Unreachable

`CAL_Z` reads `t0_offset_z` from `save_variables` without a default. That key is only written by `_CZ_FINALIZE` after a successful run, so a new install never has it.

README says: home (optional), then `CAL_Z`. Following that path, the banner or finalize raises a Jinja error and Z calibration never completes.

### Summary

- Use `|default(0.0)` at the two read sites (banner + `_CZ_FINALIZE`)
- Same pattern as `_PICKUP_TOOL` / `global_z_offset`
- First run treats missing T0 Z as 0; re-runs still use a saved value


## Issue - Hardware damage

After the last probe sample, Z is near the bed. Mid-tool swaps already lift to toolchange_z before CHANGE_TOOL, but _CZ_FINALIZE called bare PARK_TOOL (default ZHOP=0), so the park XY move occurs at probe height. This is essentially certain to drag the nozzle across the plate.

### Summary
Reuse Z lift logic from _CZ_NEXT_TOOL
