### PR TITLE
fix: LOAD_FILAMENT hangs on TEMPERATURE_WAIT

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -838,6 +838,10 @@ gcode:
     RESPOND MSG="LOAD_FILAMENT: heating T{t} to {temp|int} C..."
     M104 S{temp}
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={temp - 3} MAXIMUM={temp + 3}
+    
+    {% if measure %}
+    	G4 P4000
+    {% endif %}
 
     # 4. Feed and prime. MEASURE=1 measures + applies the heat capacity for this
     #    exact filament (APPLY=1); otherwise the TYPE preset is kept (APPLY=0).

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -837,7 +837,7 @@ gcode:
     # 3. Heat to load temperature and wait
     RESPOND MSG="LOAD_FILAMENT: heating T{t} to {temp|int} C..."
     M104 S{temp}
-    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={temp}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={temp - 3} MAXIMUM={temp + 3}
 
     # 4. Feed and prime. MEASURE=1 measures + applies the heat capacity for this
     #    exact filament (APPLY=1); otherwise the TYPE preset is kept (APPLY=0).


### PR DESCRIPTION
# fix: LOAD_FILAMENT hangs on TEMPERATURE_WAIT

Fixes #19

## Issue

`LOAD_FILAMENT` does:

```
M104 S{temp}
TEMPERATURE_WAIT SENSOR=extruder MINIMUM={temp}
```

Induction heaters can settle 0.1-0.2 C under the setpoint and hold there. `MINIMUM={temp}` never trips, so the macro hangs forever before feed/prime. Same failure mode reported in #19.

## Summary

Widen the wait to ±3 C:

```
TEMPERATURE_WAIT SENSOR=extruder MINIMUM={temp - 3} MAXIMUM={temp + 3}
```

Only change is in `macros/indx-cal.cfg` (`LOAD_FILAMENT`).