### PR TITLE
fix(macros): slow TPU guided filament load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,7 +1313,7 @@ LOAD_FILAMENT TOOL=0 TYPE=PLA
 ```
 
 - **`TOOL=<n>`** — which tool to load (it is picked up automatically).
-- **`TYPE=<material>`** — applies a density + heat-capacity preset and a default load temperature. Built-in types: `PLA`, `PETG`, `ABS`, `ASA`, `PA`, `PC`, `TPU`. Edit the `filament_presets` table in `indx-cal.cfg` to add materials or tune values.
+- **`TYPE=<material>`** — applies a density + heat-capacity preset and a default load temperature. Built-in types: `PLA`, `PETG`, `ABS`, `ASA`, `PA`, `PC`, `TPU`. Edit the `filament_presets` table in `indx-cal.cfg` to add materials or tune values. Presets may also set an optional `speed` (mm/s) for the feed/prime step; `TPU` uses 2 mm/s so soft filament does not buckle during guided load.
 - **`TEMP=<°C>`** *(optional)* — override the preset load temperature.
 - **`MEASURE=1`** *(optional)* — measure this filament's actual heat capacity while loading instead of using the preset (most accurate). Run `SAVE_CONFIG` afterwards to keep it.
 
@@ -1336,7 +1336,7 @@ Either approach significantly reduces the risk of tubes interfering with docked 
 
 **Flexible filaments (TPU and similar)**
 
-Keep the filament path as short as possible. Long Bowden paths cause flex filament to buckle rather than feed. Where possible, feed directly into the tool without a Bowden tube, or use a very short, straight tube. Avoid sharp bends in the path.
+Keep the filament path as short as possible. Long Bowden paths cause flex filament to buckle rather than feed. Where possible, feed directly into the tool without a Bowden tube, or use a very short, straight tube. Avoid sharp bends in the path. `LOAD_FILAMENT TYPE=TPU` also feeds slower than other presets (2 mm/s); tune `speed` in `filament_presets` if needed.
 
 ### Performing Tool Changes
 

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -796,13 +796,14 @@ gcode:
 #  thermal model — run INDX_CALIBRATE first.
 #
 #  Edit filament_presets to add materials or tune values
-#  (temp °C / density g/cm^3 / heat capacity J/g/K).
+#  (temp °C / density g/cm^3 / heat capacity J/g/K / optional speed mm/s).
+#  speed is passed to INDX_LOAD_FILAMENT; omit it to use the firmware default.
 #
 #####################################################################
 
 [gcode_macro LOAD_FILAMENT]
 description: Pick up TOOL=n, set filament TYPE, heat, and load+prime. Optional TEMP= override; MEASURE=1 measures the heat capacity instead of using the preset.
-variable_filament_presets: {"PLA": {"temp": 210, "density": 1.24, "hc": 1.80}, "PETG": {"temp": 240, "density": 1.27, "hc": 1.30}, "ABS": {"temp": 245, "density": 1.04, "hc": 1.40}, "ASA": {"temp": 250, "density": 1.07, "hc": 1.40}, "PA": {"temp": 260, "density": 1.14, "hc": 1.70}, "PC": {"temp": 270, "density": 1.20, "hc": 1.20}, "TPU": {"temp": 230, "density": 1.21, "hc": 1.80}}
+variable_filament_presets: {"PLA": {"temp": 210, "density": 1.24, "hc": 1.80}, "PETG": {"temp": 240, "density": 1.27, "hc": 1.30}, "ABS": {"temp": 245, "density": 1.04, "hc": 1.40}, "ASA": {"temp": 250, "density": 1.07, "hc": 1.40}, "PA": {"temp": 260, "density": 1.14, "hc": 1.70}, "PC": {"temp": 270, "density": 1.20, "hc": 1.20}, "TPU": {"temp": 230, "density": 1.21, "hc": 1.80, "speed": 2.0}}
 gcode:
     {% set presets = printer["gcode_macro LOAD_FILAMENT"].filament_presets %}
     {% if 'TOOL' not in params %}
@@ -831,7 +832,7 @@ gcode:
     # 2. Tell the safety model which filament this is (skipped when measuring)
     {% if type and not measure %}
         INDX_SET_MODEL_PARAMS FILAMENT_DENSITY={presets[type]['density']} FILAMENT_HEAT_CAPACITY={presets[type]['hc']}
-        RESPOND MSG="LOAD_FILAMENT: T{t} {type} — density {presets[type]['density']} g/cm^3, heat capacity {presets[type]['hc']} J/g/K"
+        RESPOND MSG="LOAD_FILAMENT: T{t} {type} - density {presets[type]['density']} g/cm^3, heat capacity {presets[type]['hc']} J/g/K"
     {% endif %}
 
     # 3. Heat to load temperature and wait
@@ -841,9 +842,16 @@ gcode:
 
     # 4. Feed and prime. MEASURE=1 measures + applies the heat capacity for this
     #    exact filament (APPLY=1); otherwise the TYPE preset is kept (APPLY=0).
-    INDX_LOAD_FILAMENT APPLY={measure}
+    #    Optional preset speed (mm/s) overrides INDX_LOAD_FILAMENT default - TPU needs
+    #    a slow feed or soft filament buckles and can wrap around the Smart Head.
+    {% if type and 'speed' in presets[type] %}
+        RESPOND MSG="LOAD_FILAMENT: feeding at {presets[type]['speed']} mm/s ({type} preset)"
+        INDX_LOAD_FILAMENT APPLY={measure} SPEED={presets[type]['speed']}
+    {% else %}
+        INDX_LOAD_FILAMENT APPLY={measure}
+    {% endif %}
     {% if measure %}
-        RESPOND MSG="LOAD_FILAMENT: measured heat capacity applied — run SAVE_CONFIG to keep it."
+        RESPOND MSG="LOAD_FILAMENT: measured heat capacity applied - run SAVE_CONFIG to keep it."
     {% endif %}
 
 


### PR DESCRIPTION
## Summary
- `LOAD_FILAMENT TYPE=TPU` previously fed at the default `INDX_LOAD_FILAMENT` speed of 10 mm/s (~24 mm³/s for 1.75 mm filament). Soft TPU can buckle at that rate and wrap around the Smart Head.
- Add optional `speed` to `filament_presets` and set TPU to 2 mm/s (~4.8 mm³/s), passed through as `SPEED=` to `INDX_LOAD_FILAMENT`. Other materials keep the firmware default.
- Document the optional preset speed and the TPU slower load in the README.