### PR TITLE
fix: sync latch soft-state after load-cell cal and give tool back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,14 +1047,14 @@ Start with **no tool on the Smart Head** and run:
 CALIBRATE_LOAD_CELL
 ```
 
-This homes X and Y, opens the latch, and tares the empty head. Now **seat a passive tool on the Smart Head by hand**, then lock it and calibrate against the known locking force (default 1600 g):
+This homes X and Y, opens the latch (and records soft-state Open), and tares the empty head. Now **seat a passive tool on the Smart Head by hand**, then calibrate against the known locking force (default 1600 g). `CALIBRATE_LOAD_CELL_APPLY` locks, samples, then unlocks again so you can remove the tool by hand.
 
 ```gcode
 CALIBRATE_LOAD_CELL_APPLY GRAMS=1600
 SAVE_CONFIG
 ```
 
-Prefer the console? Run `LOAD_CELL_CALIBRATE`, then `TARE` with no tool, seat a tool and lock the latch, then `CALIBRATE GRAMS=1600`, `ACCEPT`, and `SAVE_CONFIG`.
+Prefer the console? Run `LOAD_CELL_CALIBRATE`, then `TARE` with no tool, seat a tool and lock the latch, then `CALIBRATE GRAMS=1600`, `ACCEPT`, unlock the latch, and `SAVE_CONFIG`.
 
 Restart, then home the printer (`G28`) — Z now probes with the load cell.
 

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -861,10 +861,11 @@ gcode:
 #  Two steps:
 #
 #    1) CALIBRATE_LOAD_CELL            (NO tool mounted)
-#         Homes X and Y, opens the latch, tares the empty head.
+#         Homes X and Y, opens the latch, syncs toolhead_state=Open, tares.
 #    2) (seat a passive tool by hand)
 #       CALIBRATE_LOAD_CELL_APPLY GRAMS=1600
-#         Locks the latch, engages the locking force, calibrates, accepts.
+#         Locks for the force sample, calibrates, accepts, then unlocks
+#         and syncs toolhead_state=Open. Does not claim active_tool.
 #       SAVE_CONFIG
 #
 #  Note: LOAD_CELL_CALIBRATE / TARE / CALIBRATE / ACCEPT are the firmware's
@@ -875,10 +876,10 @@ gcode:
 #####################################################################
 
 [gcode_macro CALIBRATE_LOAD_CELL]
-description: Load cell calibration step 1 of 2 — run before first Z homing with NO tool mounted. Homes X and Y, opens the latch, and tares the empty head, then prompts you to seat a tool and run CALIBRATE_LOAD_CELL_APPLY.
+description: Load cell calibration step 1 of 2 - run before first Z homing with NO tool mounted. Homes X and Y, opens the latch (soft-state Open), and tares the empty head, then prompts you to seat a tool and run CALIBRATE_LOAD_CELL_APPLY.
 gcode:
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
-    # Home X and Y — Z is NOT homed yet; Z homing needs the calibrated load cell.
+    # Home X and Y - Z is NOT homed yet; Z homing needs the calibrated load cell.
     G28 X Y
     LOAD_CELL_CALIBRATE
     # Open the latch so a passive tool can be seated by hand
@@ -887,12 +888,14 @@ gcode:
     _TC_RESTORE_ROTATION_DIST
     M400
     G4 P500
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
     # Tare the empty head
     TARE
     RESPOND MSG="Load cell tared (empty head). Seat a passive tool on the Smart Head by hand, then run: CALIBRATE_LOAD_CELL_APPLY GRAMS=1600"
 
 [gcode_macro CALIBRATE_LOAD_CELL_APPLY]
-description: Load cell calibration step 2 of 2 — with a tool seated by hand, locks the latch, applies the locking force, and calibrates against GRAMS (default 1600). Run SAVE_CONFIG after.
+description: Load cell calibration step 2 of 2 - with a tool seated by hand, locks for the force sample, calibrates against GRAMS (default 1600), then unlocks (soft-state Open, no active_tool claim). Run SAVE_CONFIG after.
 gcode:
     {% set grams = params.GRAMS|default(1600)|float %}
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
@@ -906,4 +909,12 @@ gcode:
     G4 P500
     CALIBRATE GRAMS={grams}
     ACCEPT
-    RESPOND MSG="Load cell calibrated against {grams|int} g. Run SAVE_CONFIG to save."
+    # Unlock after cal - soft-state must match physical latch. Do not claim
+    # active_tool: the hand-seated tool is not a dock pickup.
+    _TC_SET_ROTATION_DIST
+    _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate}
+    _TC_RESTORE_ROTATION_DIST
+    M400
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+    RESPOND MSG="Load cell calibrated against {grams|int} g. Latch unlocked. Remove the tool by hand, then run SAVE_CONFIG."


### PR DESCRIPTION
# fix: sync latch state after load-cell cal and give tool back

## Issue

Current behaviour is:
- Annoying
- Likely to cause crashes 

`CALIBRATE_LOAD_CELL` / `CALIBRATE_LOAD_CELL_APPLY` move the latch but never write `toolhead_state`. Latch ends up locked after step 2, but state claims it is Open.

`PARK_TOOL` / `_PICKUP_TOOL` skip the unlock dance when state=Open, and can drive into the dock with a locked tool. Soft Locked + physically Open can open again off-dock or take the wrong branch on the next swap.

## Summary

- After step 1 opens the latch: set `toolhead_state=2` (Open)
- After APPLY finishes `CALIBRATE`/`ACCEPT`: unlock the latch, then set `toolhead_state=2`, and give the user their tool back.

Only `macros/indx-cal.cfg` (plus README wording for the new end state).