### PR TITLE
fix: warn to unload filament before CAL_Z and load-cell cal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,14 +1047,14 @@ Start with **no tool on the Smart Head** and run:
 CALIBRATE_LOAD_CELL
 ```
 
-This homes X and Y, opens the latch, and tares the empty head. Now **seat a passive tool on the Smart Head by hand**, then lock it and calibrate against the known locking force (default 1600 g):
+This homes X and Y, opens the latch, and tares the empty head. Now **seat a passive tool on the Smart Head by hand** — the tool **must be empty** (no filament in the extruder gears) — then lock it and calibrate against the known locking force (default 1600 g):
 
 ```gcode
 CALIBRATE_LOAD_CELL_APPLY GRAMS=1600
 SAVE_CONFIG
 ```
 
-Prefer the console? Run `LOAD_CELL_CALIBRATE`, then `TARE` with no tool, seat a tool and lock the latch, then `CALIBRATE GRAMS=1600`, `ACCEPT`, and `SAVE_CONFIG`.
+Prefer the console? Run `LOAD_CELL_CALIBRATE`, then `TARE` with no tool, seat an **empty** tool and lock the latch, then `CALIBRATE GRAMS=1600`, `ACCEPT`, and `SAVE_CONFIG`.
 
 Restart, then home the printer (`G28`) — Z now probes with the load cell.
 
@@ -1230,6 +1230,7 @@ CAL_Z
 
 Prerequisites:
 - Printer homed (homes automatically if not)
+- **No filament available to the extruder gears in any tool** — latch engage moves during pickup can spike load-cell readings and calibration to fail if filament is loaded.
 
 Per tool, the macro:
 1. Picks up the tool

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -184,6 +184,7 @@ variable_probe_retract:      1.0   # Z retract between convergence/sample probes
 variable_toolchange_z:      20.0   # minimum Z before each CHANGE_TOOL (nozzle clearance, mm)
 variable_sample_count:         5   # final clean probes per tool — median saved as result
 gcode:
+    RESPOND MSG="CAL_Z: Make sure no filament is available to the extruder gears in any tool."
     {% set tp  = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set svv = printer.save_variables.variables %}
     {% set cfg = printer["gcode_macro CAL_Z"] %}
@@ -889,11 +890,12 @@ gcode:
     G4 P500
     # Tare the empty head
     TARE
-    RESPOND MSG="Load cell tared (empty head). Seat a passive tool on the Smart Head by hand, then run: CALIBRATE_LOAD_CELL_APPLY GRAMS=1600"
+    RESPOND MSG="Load cell tared (empty head). Seat a passive tool on the Smart Head by hand - the tool MUST BE EMPTY (no filament loaded). Then run: CALIBRATE_LOAD_CELL_APPLY GRAMS=1600"
 
 [gcode_macro CALIBRATE_LOAD_CELL_APPLY]
 description: Load cell calibration step 2 of 2 — with a tool seated by hand, locks the latch, applies the locking force, and calibrates against GRAMS (default 1600). Run SAVE_CONFIG after.
 gcode:
+    RESPOND MSG="CALIBRATE_LOAD_CELL_APPLY: the seated tool MUST BE EMPTY (no filament loaded)."
     {% set grams = params.GRAMS|default(1600)|float %}
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
     # Lock the latch onto the seated tool, then drive it to fully engage the


### PR DESCRIPTION
## Summary
- Add `RESPOND` warnings to `CAL_Z`, `CALIBRATE_LOAD_CELL`, and `CALIBRATE_LOAD_CELL_APPLY` reminding the operator that tools must have no filament loaded
- Document the same requirement in the README load-cell and `CAL_Z` sections

Latch engage moves during calibration can spike load-cell readings when filament is present in the tool, biasing Z offset and `counts_per_gram` calibration.

Closes https://github.com/BondtechAB/INDX/issues/22

## Test plan
- [x] Run `CAL_Z` and confirm the filament warning appears in the console
- [x] Run `CALIBRATE_LOAD_CELL` / `CALIBRATE_LOAD_CELL_APPLY` and confirm empty-tool warnings appear
- [x] Verify README sections match macro messaging