### PR TITLE
feat: load-cell tool detection and latch helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
    - [Firmware Configuration](#firmware-configuration)
      - [Klipper / Kalico](#klipper)
        - [INDX macro files](#indx-macro-files)
+       - [Mainsail RESUME coexistence](#mainsail-resume-coexistence)
        - [Automated dock X measurement](#automated-dock-x-measurement-built-in)
        - [Homing override](#homing-order-important)
      - [RRF (RepRapFirmware)](#rrf-reprapfirmware)
@@ -851,6 +852,7 @@ The INDX firmware plugin provides a set of `.cfg` files you include from `printe
 | `indx.cfg` | User configuration: tool positions and related settings. **The only file you need to edit.** |
 | `indx-tc-macros.cfg` | Tool change logic: `CHANGE_TOOL`, `PARK_TOOL`, boot detection. Do not edit. |
 | `indx-cal.cfg` | Calibration macros: dock position, XY/Z offset calibration. |
+| `indx-helpers.cfg` | Optional helpers: latch lock/unlock, load-cell tool presence, RESUME wrapper for mid-print detect. Include after `indx-tc-macros.cfg`. |
 
 Include them from your `printer.cfg`:
 
@@ -858,7 +860,24 @@ Include them from your `printer.cfg`:
 [include indx/indx.cfg]
 [include indx/indx-tc-macros.cfg]
 [include indx/indx-cal.cfg]
+[include indx/indx-helpers.cfg]   # after tc-macros; after mainsail.cfg in printer.cfg
 ```
+
+##### Mainsail RESUME coexistence
+
+If you use Mainsail's stock `mainsail.cfg`, it defines `[gcode_macro RESUME]`. Klipper merges duplicate section names; when `indx-helpers.cfg` is included later, INDX's RESUME (tool-detect recheck) replaces Mainsail's body. Without a printer-side patch, Mainsail's temp restore, runout gate, and `_CLIENT_EXTRUDE` never run.
+
+INDX owns the `RESUME` command and `rename_existing: RESUME_BASE`. Move Mainsail's wrapper to `_CLIENT_RESUME` in your local `mainsail.cfg` (or a small override file included after Mainsail):
+
+1. Rename `[gcode_macro RESUME]` to `[gcode_macro _CLIENT_RESUME]`
+2. Remove `rename_existing: RESUME_BASE` from that section (INDX already renames the builtin)
+3. In `CANCEL_PRINT`, change `printer['gcode_macro RESUME']` to `printer['gcode_macro _CLIENT_RESUME']`
+4. In `CANCEL_PRINT`, `PAUSE`, and the renamed section body, change every `SET_GCODE_VARIABLE MACRO=RESUME` to `MACRO=_CLIENT_RESUME`
+5. Keep `RESUME_BASE VELOCITY=...` at the end of `_CLIENT_RESUME`
+
+Call chain after the patch: `RESUME` (INDX) -> optional `_RESUME_PRESENCE_*` on tool-detect fail -> `_CLIENT_RESUME` (Mainsail) -> `RESUME_BASE` (Klipper). If `_CLIENT_RESUME` is missing, INDX falls back to `RESUME_BASE` so resume still works.
+
+After editing, run `FIRMWARE_RESTART`. `HELP` should show INDX's RESUME description.
 
 ##### Automated dock X measurement (built in)
 

--- a/README.md
+++ b/README.md
@@ -894,26 +894,27 @@ The `indx-cal.cfg` macros wrap this into the calibration commands you actually r
 
 ##### Homing order (important)
 
-With a dock mounted on your printer, the default homing sequence can cause crashes. The Smart Head must move away from the dock before X is homed, and if a tool other than T0 is currently mounted it must be parked before Z is homed.
+With a dock mounted on your printer, the default homing sequence can cause crashes. The Smart Head must move away from the dock before X is homed, and Z homing needs a seated tool (the load cell is the nozzle probe).
 
 The INDX macro package includes a ready-to-use `[homing_override]` in `homing.cfg` that handles all of this. Its sequence, in full:
 
-1. Move Z up slightly to clear the bed before any XY movement (move bed down if using a bed raiser)
-2. Home Y (with reduced TMC current for sensorless homing)
-3. Home X (with reduced TMC current for sensorless homing)
-4. If any tool other than T0 is active: park it in the dock
-5. If T0 is not already picked up: pick up T0
-6. Move to bed centre and home Z
+1. If Z is already known: raise to `probe_z_clearance` (set in `indx.cfg`)
+2. Home Y, then move to `clearance_y` so X does not sweep into the dock
+3. Home X
+4. Before Z: require a seated tool (`VERIFY_TOOL_PRESENT`). If a tool is already locked, Z homes with that tool (its XY/Z offsets are re-applied before the probe). If the head is empty and the dock is usable, pick T0. If Z has never been homed, dock pickup is unsafe - seat and lock a tool by hand after load-cell calibration, then home. Empty-head Z without a known tool is refused (the load cell will not trigger without a nozzle).
+5. Move to the probe XY (`probe_x` / `probe_y`, or bed centre) and home Z
 
-T0 is always the reference tool for Z homing. This ensures Z is always probed with the same tool, keeping Z offsets for all other tools consistent.
+`CAL_Z` still stores per-tool Z offsets relative to T0. Homing no longer requires T0 when another tool is already locked - toolchanges keep applying `tool_z + global_z`, so nozzle height stays consistent after a non-T0 Z home. Mesh or tilt after that home (as in `PRINT_START`) keeps the frame consistent.
+
+If you use sensorless XY homing, wrap the `G28 Y` / `G28 X` steps in your usual TMC current reduce/restore (merge into the override if you already have one).
 
 **Review your `PRINT_START` macro**
 
 If you are migrating from a single-toolhead printer, your existing `PRINT_START` macro almost certainly heats the hotend before printing starts, something like `M104 S{first_layer_temperature}` or `M109 S{first_layer_temperature}`. With INDX, this will cause problems: there is no hotend to heat until a tool has been picked up by the Smart Head.
 
-> ⚠️ Any hotend heating commands in your `PRINT_START` macro must come **after** the first tool pick-up (`T0`). Sending a heat command before a tool is picked up will result in an error, and depending on your macro structure, may cause a crash or leave the printer in a bad state.
+> ⚠️ Any hotend heating commands in your `PRINT_START` macro must come **after** the first tool pick-up. Sending a heat command before a tool is picked up will result in an error, and depending on your macro structure, may cause a crash or leave the printer in a bad state.
 
-Review your `PRINT_START` macro and move all `M104`/`M109` (and any temperature wait commands) to after the first `T0` call. If you are writing a fresh macro, pick up a tool first, then heat.
+Review your `PRINT_START` macro and move all `M104`/`M109` (and any temperature wait commands) to after the first tool pick (`Tn` / `CHANGE_TOOL`). If you are writing a fresh macro, pick up a tool first, then heat.
 
 #### RRF (RepRapFirmware)
 

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -1,0 +1,168 @@
+#####################################################################
+#  INDX HOMING OVERRIDE
+#####################################################################
+#
+#  Include AFTER the other INDX macros:
+#    [include indx/indx.cfg]
+#    [include indx/indx-tc-macros.cfg]
+#    [include indx/indx-cal.cfg]
+#    [include indx/homing.cfg]
+#
+#  Klipper allows only ONE [homing_override]. If your printer.cfg
+#  already has one (sensorless current, bed raiser, etc.), merge this
+#  sequence into yours - do not include both.
+#
+#  Sequence (full G28):
+#    1. _INDX_SAFE_Z_HOP before any axis home:
+#       Z known: ensure at/above probe_z_clearance; Z unknown: relative +probe_z_clearance
+#    2. Home Y if needed (X always requires Y - G28 X with Y unknown
+#       homes Y first)
+#    3. Before X: if Y already known, clear past clearance_y when on
+#       the dock side (dock_dir). Just-homed Y: home X immediately.
+#    4. Home X
+#    5. If Z requested: VERIFY, keep seated tool (or pick T0 if empty),
+#       re-apply that tool's offsets, VERIFY again, probe Z
+#
+#  G28 Z homes with whatever tool is seated:
+#    VERIFY (soft) - error only if active_tool==-1 but load cell sees a tool
+#    Seated tool (active_tool >= 0): keep it; empty head: CHANGE_TOOL T0
+#    Re-apply that tool's XY/Z offsets (MOVE=0) before probe
+#    VERIFY (hard) - home tool must be seated or Z home aborts
+#    After probe: SAVE_VARIABLE z_home_tool for support/debug
+#  CAL_Z offsets stay T0-relative; toolchange still applies tool_z+global_z.
+#  XY must be homed before G28 Z (G28 Z alone does not home XY).
+#
+#  Sensorless XY: add your TMC current reduce/restore around the
+#  G28 Y / G28 X lines if your printer needs it.
+#
+#  Manual check:
+#    - G28 with locked tool (any Tn): Y, X, Z succeed without docking to T0
+#    - G28 Z with XY unhomed: errors
+#    - G28 Z with empty head: dock-picks T0, then probes (if XY homed)
+#    - G28 X Y only: no tool pickup, no Z move
+#    - G28 X with Y unknown: homes Y, then homes X
+#    - G28 X with Y known on dock side: clears to clearance_y, then X
+#
+#####################################################################
+
+[homing_override]
+axes: xyz
+gcode:
+    {% set home_all = not ('X' in params or 'Y' in params or 'Z' in params) %}
+    {% set home_x = home_all or 'X' in params %}
+    {% set home_z = home_all or 'Z' in params %}
+    # X requires Y: G28 X with Y unknown homes Y first #
+    {% set home_y = home_all or 'Y' in params
+        or (home_x and "y" not in printer.toolhead.homed_axes) %}
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=1
+
+    # 1. Clear Z before any axis home
+    _INDX_SAFE_Z_HOP
+
+    # 2. Home Y first (dock is usually on Y-min; X-first can sweep into tools)
+    {% if home_y %}
+        G28 Y
+    {% endif %}
+
+    # 3. Before X: if Y was already known, ensure clear of docks.
+    # Just-homed Y: endstop is fine for X - home X immediately.
+    {% if home_x %}
+        {% if not home_y %}
+            {% set cur_y = printer.toolhead.position.y|float %}
+            {% set clear_y = tp.clearance_y|float %}
+            {% if (cur_y - clear_y) * (tp.dock_dir|float) > 0 %}
+                G90
+                G0 Y{clear_y} F3000
+            {% endif %}
+        {% endif %}
+        G28 X
+    {% endif %}
+
+    # 4. Z needs a seated tool (load cell = nozzle probe)
+    {% if home_z %}
+        _INDX_HOME_Z
+    {% else %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+    {% endif %}
+
+[gcode_macro _INDX_SAFE_Z_HOP]
+description: Inner - clear Z to probe_z_clearance before any axis home
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set z_clr = tp.probe_z_clearance|float %}
+    {% if "z" not in printer.toolhead.homed_axes %}
+        SET_KINEMATIC_POSITION Z=0 SET_HOMED=Z
+        G91
+        G0 Z{z_clr} F900
+        G90
+        SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z
+    {% elif printer.toolhead.position.z|float < z_clr %}
+        G90
+        G0 Z{z_clr} F900
+    {% endif %}
+
+[gcode_macro _INDX_HOME_Z]
+description: Inner - ensure a seated tool (keep current, or T0 if empty), then probe Z
+gcode:
+    {% if "xy" not in printer.toolhead.homed_axes %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+        {action_raise_error("Must home X and Y before Z")}
+    {% endif %}
+
+    # 1. Soft verify - only refuse when a tool is on the load cell but state is unknown
+    VERIFY_TOOL_PRESENT QUIET=1 SOFT=1
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+    {% if act == -1 and vd.last_ok|int == 1 %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+        {action_raise_error("Cannot home Z: tool detected but active_tool is unknown (-1). Run CHANGE_TOOL or fix latch state.")}
+    {% endif %}
+
+    # 2. Keep seated tool; empty head falls back to T0
+    {% set home_tool = act if act >= 0 else 0 %}
+    {% if act < 0 %}
+        CHANGE_TOOL TOOL=0
+    {% endif %}
+
+    # 3. Re-apply home tool offsets before probe (MOVE=0 - no Z motion mid-home)
+    {% set svv = printer.save_variables.variables %}
+    {% set tool_x = svv["t" ~ home_tool ~ "_offset_x"]|default(0.0)|float %}
+    {% set tool_y = svv["t" ~ home_tool ~ "_offset_y"]|default(0.0)|float %}
+    {% set tool_z = svv["t" ~ home_tool ~ "_offset_z"]|default(0.0)|float %}
+    {% set global_z = svv.global_z_offset|default(0.0)|float %}
+    SET_GCODE_OFFSET X={"%.3f"|format(tool_x)} Y={"%.3f"|format(tool_y)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=0
+
+    # 4. Hard verify home tool seated before descending to the bed
+    VERIFY_TOOL_PRESENT QUIET=1 SOFT=1
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% if vd.last_ok|int != 1 %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+        {action_raise_error("T%d not seated - cannot home Z" % (home_tool,))}
+    {% endif %}
+
+    _INDX_HOME_Z_PROBE
+
+[gcode_macro _INDX_HOME_Z_PROBE]
+description: Inner - move to probe XY and G28 Z
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set th = printer.toolhead %}
+    {% set px = tp.probe_x|float %}
+    {% set py = tp.probe_y|float %}
+    {% if px < 0 %}
+        {% set px = (th.axis_minimum.x + th.axis_maximum.x) / 2 %}
+    {% endif %}
+    {% if py < 0 %}
+        {% set py = (th.axis_minimum.y + th.axis_maximum.y) / 2 %}
+    {% endif %}
+
+    G90
+    {% if "xy" in printer.toolhead.homed_axes %}
+        G0 X{"%.3f"|format(px)} Y{"%.3f"|format(py)} F3000
+    {% endif %}
+    G28 Z
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+    SAVE_VARIABLE VARIABLE=z_home_tool VALUE={act}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -24,10 +24,11 @@
 #       re-apply that tool's offsets, VERIFY again, probe Z
 #
 #  G28 Z homes with whatever tool is seated:
-#    VERIFY (soft) - error only if active_tool==-1 but load cell sees a tool
-#    Seated tool (active_tool >= 0): keep it; empty head: CHANGE_TOOL T0
-#    Re-apply that tool's XY/Z offsets (MOVE=0) before probe
-#    VERIFY (hard) - home tool must be seated or Z home aborts
+#    VERIFY (soft) then _INDX_HOME_Z_AFTER_SOFT (Jinja split - last_ok)
+#      error only if active_tool==-1 but load cell sees a tool
+#      Seated tool (active_tool >= 0): keep it; empty head: CHANGE_TOOL T0
+#      Re-apply that tool's XY/Z offsets (MOVE=0) before probe
+#    VERIFY (hard) then _INDX_HOME_Z_AFTER_HARD - seated or abort
 #    After probe: SAVE_VARIABLE z_home_tool for support/debug
 #  CAL_Z offsets stay T0-relative; toolchange still applies tool_z+global_z.
 #  XY must be homed before G28 Z (G28 Z alone does not home XY).
@@ -105,28 +106,37 @@ gcode:
 
 [gcode_macro _INDX_HOME_Z]
 description: Inner - ensure a seated tool (keep current, or T0 if empty), then probe Z
+variable_home_tool: 0
 gcode:
     {% if "xy" not in printer.toolhead.homed_axes %}
         SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
         {action_raise_error("Must home X and Y before Z")}
     {% endif %}
 
-    # 1. Soft verify - only refuse when a tool is on the load cell but state is unknown
+    # Soft verify, then read last_ok in a follow-up (Jinja cannot see it in this macro).
     VERIFY_TOOL_PRESENT QUIET=1 SOFT=1
+    _INDX_HOME_Z_AFTER_SOFT
+
+[gcode_macro _INDX_HOME_Z_AFTER_SOFT]
+description: Inner - after soft VERIFY: keep seated tool or pick T0, re-apply offsets, hard VERIFY
+gcode:
     {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
     {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+
+    # Refuse when a tool is on the load cell but soft-state is unknown
     {% if act == -1 and vd.last_ok|int == 1 %}
         SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
         {action_raise_error("Cannot home Z: tool detected but active_tool is unknown (-1). Run CHANGE_TOOL or fix latch state.")}
     {% endif %}
 
-    # 2. Keep seated tool; empty head falls back to T0
+    # Keep seated tool; empty head falls back to T0
     {% set home_tool = act if act >= 0 else 0 %}
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=home_tool VALUE={home_tool}
     {% if act < 0 %}
         CHANGE_TOOL TOOL=0
     {% endif %}
 
-    # 3. Re-apply home tool offsets before probe (MOVE=0 - no Z motion mid-home)
+    # Re-apply home tool offsets before probe (MOVE=0 - no Z motion mid-home)
     {% set svv = printer.save_variables.variables %}
     {% set tool_x = svv["t" ~ home_tool ~ "_offset_x"]|default(0.0)|float %}
     {% set tool_y = svv["t" ~ home_tool ~ "_offset_y"]|default(0.0)|float %}
@@ -134,9 +144,15 @@ gcode:
     {% set global_z = svv.global_z_offset|default(0.0)|float %}
     SET_GCODE_OFFSET X={"%.3f"|format(tool_x)} Y={"%.3f"|format(tool_y)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=0
 
-    # 4. Hard verify home tool seated before descending to the bed
+    # Hard verify, then read last_ok in a follow-up before descending
     VERIFY_TOOL_PRESENT QUIET=1 SOFT=1
+    _INDX_HOME_Z_AFTER_HARD
+
+[gcode_macro _INDX_HOME_Z_AFTER_HARD]
+description: Inner - after hard VERIFY: abort if not seated, else probe Z
+gcode:
     {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% set home_tool = printer["gcode_macro _INDX_HOME_Z"].home_tool|int %}
     {% if vd.last_ok|int != 1 %}
         SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
         {action_raise_error("T%d not seated - cannot home Z" % (home_tool,))}

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -154,8 +154,6 @@ gcode:
         {% if vd.pending_target|float > 0 %}
             M104 S{vd.pending_target|float}
         {% endif %}
-        {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
-        M106 S{c.post_pickup_fan_s|int}
         _RECORD_TOOLCHANGE TOOL={t}
         SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_recheck VALUE=0
         SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_tool VALUE=-1

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -1,0 +1,167 @@
+#####################################################################
+#  INDX HELPERS
+#####################################################################
+#
+#  Include after indx-tc-macros.cfg:
+#    [include indx/indx-tc-macros.cfg]
+#    [include indx/indx-helpers.cfg]
+#
+#  Latch (in place, no dock move):
+#    INDX_LOCK
+#    INDX_UNLOCK
+#    INDX_FORCE_STATE ACTIVE_TOOL=<n|-1>   # soft-state only
+#
+#  Tool presence (needs calibrated load cell):
+#    VERIFY_TOOL_PRESENT                  # manual check
+#    Pickup runs detect automatically.
+#    Mid-print fail: seat tool by hand, then RESUME
+#
+#####################################################################
+
+[gcode_macro INDX_FORCE_STATE]
+description: Set ACTIVE_TOOL soft-state only (no latch move). ACTIVE_TOOL=<n|-1>
+gcode:
+    {% if "ACTIVE_TOOL" not in params %}
+        {action_raise_error("Usage: INDX_FORCE_STATE ACTIVE_TOOL=<n|-1>")}
+    {% endif %}
+    {% set t = params.ACTIVE_TOOL|int %}
+    {% set n = printer["gcode_macro TOOL_POSITIONS"].tool_count|int %}
+    {% if t < -1 or t >= n %}
+        {action_raise_error("ACTIVE_TOOL=%d out of range (-1..%d)"|format(t, n - 1))}
+    {% endif %}
+    SAVE_VARIABLE VARIABLE=active_tool VALUE={t}
+    RESPOND MSG="INDX_FORCE_STATE: active_tool={'NONE' if t < 0 else ('T' ~ t)}"
+
+[gcode_macro INDX_UNLOCK]
+description: Open latch in place (no dock dance)
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    _TC_SET_ROTATION_DIST
+    _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate} I={c.run_current}
+    _TC_RESTORE_ROTATION_DIST
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+    RESPOND MSG="INDX_UNLOCK: latch open"
+
+[gcode_macro INDX_LOCK]
+description: Close latch in place (no dock dance)
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    _TC_SET_ROTATION_DIST
+    _TC_LATCH_MOVE E={c.full_lock_e} F={c.latch_feedrate} I={c.run_current}
+    _TC_RESTORE_ROTATION_DIST
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=0
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=0
+    RESPOND MSG="INDX_LOCK: latch locked"
+
+[gcode_macro VERIFY_TOOL_PRESENT]
+description: Check tool is seated via load cell. Mid-print fail: seat by hand, then RESUME.
+variable_last_ok: -1
+variable_last_force_g: 0.0
+variable_last_msg: ""
+variable_quiet: 0
+variable_soft: 0
+variable_pending_recheck: 0
+variable_pending_tool: -1
+variable_pending_target: 0.0
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    {% set quiet = params.QUIET|default(0)|int %}
+    {% set soft = params.SOFT|default(0)|int %}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=quiet VALUE={quiet}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=soft VALUE={soft}
+    M400
+    G4 P{c.tool_detect_settle_ms|int}
+    _VERIFY_TOOL_PRESENT_CHECK
+
+[gcode_macro _VERIFY_TOOL_PRESENT_CHECK]
+description: Inner - read absolute force after settle
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    {% set v = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% set min_g = c.tool_detect_min_force_g|float %}
+    {% set ns = namespace(force=none, ok=0, msg="", force_save=0.0) %}
+
+    {% if "load_cell_probe" in printer %}
+        {% set lc = printer.load_cell_probe %}
+        {% if lc.is_calibrated|default(false) %}
+            {% set fg = lc.force_g|default(none) %}
+            {% if fg is not none %}
+                {% set ns.force = fg|float + (lc.tare_force|default(0.0)|float) %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
+    {% if ns.force is none %}
+        {% if v.soft|int %}
+            {% set ns.ok = 0 %}
+            {% set ns.msg = "VERIFY_TOOL_PRESENT: no force reading - refuse pickup ([load_cell_probe] missing, uncalibrated, or force_g unavailable)" %}
+        {% else %}
+            {% set ns.ok = 1 %}
+            {% set ns.msg = "VERIFY_TOOL_PRESENT: skipped ([load_cell_probe] missing, uncalibrated, or force_g unavailable)" %}
+        {% endif %}
+        RESPOND MSG="{ns.msg}"
+    {% elif ns.force|abs >= min_g %}
+        {% set ns.ok = 1 %}
+        {% set ns.force_save = ns.force %}
+        {% set ns.msg = "VERIFY_TOOL_PRESENT: ok (%.1fg abs >= %.1fg)"|format(ns.force|abs, min_g) %}
+        {% if not v.quiet|int %}
+            RESPOND MSG="{ns.msg}"
+        {% endif %}
+    {% else %}
+        {% set ns.ok = 0 %}
+        {% set ns.force_save = ns.force %}
+        {% set ns.msg = "VERIFY_TOOL_PRESENT: no tool seated (%.1fg abs < %.1fg min). Empty dock or failed lock?"|format(ns.force|abs, min_g) %}
+    {% endif %}
+
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_ok VALUE={ns.ok}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_force_g VALUE={ns.force_save}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_msg VALUE='"{ns.msg}"'
+
+    {% if ns.ok|int == 0 and not v.soft|int %}
+        {action_raise_error(ns.msg)}
+    {% endif %}
+
+[gcode_macro RESUME]
+description: Resume print. After tool-detect PAUSE: seat tool by hand, then RESUME.
+rename_existing: RESUME_BASE
+gcode:
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% if vd.pending_recheck|int == 1 %}
+        _RESUME_PRESENCE_RECHECK
+    {% else %}
+        RESUME_BASE
+    {% endif %}
+
+[gcode_macro _RESUME_PRESENCE_RECHECK]
+description: Inner - re-check seat after mid-print detect fail
+gcode:
+    VERIFY_TOOL_PRESENT QUIET=0 SOFT=1
+    _RESUME_PRESENCE_SYNC
+
+[gcode_macro _RESUME_PRESENCE_SYNC]
+description: Inner - continue on pass, stay paused on fail
+gcode:
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% set t = vd.pending_tool|int %}
+    {% if vd.last_ok|int == 1 %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=0
+        SAVE_VARIABLE VARIABLE=toolhead_state VALUE=0
+        {% set svv = printer.save_variables.variables %}
+        {% set tool_z = svv["t" ~ t ~ "_offset_z"]|default(0.0)|float %}
+        {% set global_z = svv.global_z_offset|default(0.0)|float %}
+        SET_GCODE_OFFSET X={svv["t"~t~"_offset_x"]|default(0.0)} Y={svv["t"~t~"_offset_y"]|default(0.0)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=1
+        {% if vd.pending_target|float > 0 %}
+            M104 S{vd.pending_target|float}
+        {% endif %}
+        {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+        M106 S{c.post_pickup_fan_s|int}
+        _RECORD_TOOLCHANGE TOOL={t}
+        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_recheck VALUE=0
+        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_tool VALUE=-1
+        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_target VALUE=0
+        RESPOND MSG="Tool detect ok on resume. Continuing print with T{t}."
+        RESUME_BASE
+    {% else %}
+        RESPOND MSG="Tool still not detected. Seat and lock T{t} on the Smart Head by hand, then RESUME again."
+    {% endif %}

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -84,6 +84,7 @@ variable_last_force_g: 0.0
 variable_last_msg: ""
 variable_quiet: 0
 variable_soft: 0
+variable_attempts_remaining: 1
 variable_pending_recheck: 0
 variable_pending_tool: -1
 variable_pending_target: 0.0
@@ -91,11 +92,15 @@ gcode:
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
     {% set quiet = params.QUIET|default(0)|int %}
     {% set soft = params.SOFT|default(0)|int %}
+    {% set raw_attempts = params.ATTEMPTS|default(c.tool_detect_attempts)|int %}
+    {% set attempts = raw_attempts if raw_attempts >= 1 else 1 %}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=quiet VALUE={quiet}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=soft VALUE={soft}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=attempts_remaining VALUE={attempts}
     M400
     G4 P{c.tool_detect_settle_ms|int}
     _VERIFY_TOOL_PRESENT_CHECK
+    _VERIFY_TOOL_PRESENT_RETRY
 
 [gcode_macro _VERIFY_TOOL_PRESENT_CHECK]
 description: Inner - read absolute force after settle
@@ -141,8 +146,22 @@ gcode:
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_force_g VALUE={ns.force_save}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_msg VALUE='"{ns.msg}"'
 
-    {% if ns.ok|int == 0 and not v.soft|int %}
-        {action_raise_error(ns.msg)}
+[gcode_macro _VERIFY_TOOL_PRESENT_RETRY]
+description: Inner - re-settle and re-sample on fail until tool_detect_attempts exhausted; hard-raise only then when not SOFT
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    {% set v = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% set remaining = v.attempts_remaining|int %}
+    {% if v.last_ok|int == 1 %}
+        # Pass - stop early
+    {% elif remaining > 1 %}
+        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=attempts_remaining VALUE={remaining - 1}
+        RESPOND MSG="VERIFY_TOOL_PRESENT: attempt failed ({'%.1f'|format(v.last_force_g|float)}g), retrying ({remaining - 1} left)"
+        G4 P{c.tool_detect_settle_ms|int}
+        _VERIFY_TOOL_PRESENT_CHECK
+        _VERIFY_TOOL_PRESENT_RETRY
+    {% elif not v.soft|int %}
+        {action_raise_error(v.last_msg)}
     {% endif %}
 
 [gcode_macro RESUME]

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -2,7 +2,10 @@
 #  INDX HELPERS
 #####################################################################
 #
-#  Include after indx-tc-macros.cfg:
+#  Include after indx-tc-macros.cfg, and after mainsail.cfg in
+#  printer.cfg (INDX RESUME must load after Mainsail's RESUME):
+#    [include mainsail.cfg]
+#    ...
 #    [include indx/indx-tc-macros.cfg]
 #    [include indx/indx-helpers.cfg]
 #
@@ -15,6 +18,26 @@
 #    VERIFY_TOOL_PRESENT                  # manual check
 #    Pickup runs detect automatically.
 #    Mid-print fail: seat tool by hand, then RESUME
+#
+#  --- Mainsail RESUME coexistence ---
+#
+#  Klipper merges duplicate [gcode_macro RESUME] sections; the later
+#  include wins for gcode:. This file owns RESUME (tool-detect recheck)
+#  and rename_existing: RESUME_BASE. Without a printer-side patch,
+#  Mainsail's resume body (temp restore, runout, _CLIENT_EXTRUDE) is
+#  discarded and RESUME falls back to RESUME_BASE.
+#
+#  Patch your mainsail.cfg so Mainsail's wrapper
+#  lives as _CLIENT_RESUME:
+#  **Mainsail.cfg patch:**
+#    1. [gcode_macro RESUME] -> [gcode_macro _CLIENT_RESUME]
+#    2. Remove rename_existing: RESUME_BASE from that section
+#       (INDX owns rename_existing on RESUME)
+#    3. CANCEL_PRINT: printer['gcode_macro RESUME'] ->
+#       printer['gcode_macro _CLIENT_RESUME']
+#    4. CANCEL_PRINT / PAUSE / body of the renamed section:
+#       SET_GCODE_VARIABLE MACRO=RESUME -> MACRO=_CLIENT_RESUME
+#    5. Keep RESUME_BASE VELOCITY=... at the end of _CLIENT_RESUME
 #
 #####################################################################
 
@@ -130,7 +153,11 @@ gcode:
     {% if vd.pending_recheck|int == 1 %}
         _RESUME_PRESENCE_RECHECK
     {% else %}
-        RESUME_BASE
+        {% if 'gcode_macro _CLIENT_RESUME' in printer %}
+            _CLIENT_RESUME {% if params.VELOCITY is defined %}VELOCITY={params.VELOCITY}{% endif %}
+        {% else %}
+            RESUME_BASE {% if params.VELOCITY is defined %}VELOCITY={params.VELOCITY}{% endif %}
+        {% endif %}
     {% endif %}
 
 [gcode_macro _RESUME_PRESENCE_RECHECK]
@@ -159,7 +186,11 @@ gcode:
         SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_tool VALUE=-1
         SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_target VALUE=0
         RESPOND MSG="Tool detect ok on resume. Continuing print with T{t}."
-        RESUME_BASE
+        {% if 'gcode_macro _CLIENT_RESUME' in printer %}
+            _CLIENT_RESUME {% if params.VELOCITY is defined %}VELOCITY={params.VELOCITY}{% endif %}
+        {% else %}
+            RESUME_BASE {% if params.VELOCITY is defined %}VELOCITY={params.VELOCITY}{% endif %}
+        {% endif %}
     {% else %}
         RESPOND MSG="Tool still not detected. Seat and lock T{t} on the Smart Head by hand, then RESUME again."
     {% endif %}

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -84,7 +84,7 @@ variable_last_force_g: 0.0
 variable_last_msg: ""
 variable_quiet: 0
 variable_soft: 0
-variable_attempts_remaining: 1
+variable_attempts_total: 1
 variable_pending_recheck: 0
 variable_pending_tool: -1
 variable_pending_target: 0.0
@@ -93,14 +93,20 @@ gcode:
     {% set quiet = params.QUIET|default(0)|int %}
     {% set soft = params.SOFT|default(0)|int %}
     {% set raw_attempts = params.ATTEMPTS|default(c.tool_detect_attempts)|int %}
-    {% set attempts = raw_attempts if raw_attempts >= 1 else 1 %}
+    {# Clamp 1..5. Retries are sequential sibling calls (not nested self-calls -
+       Klipper forbids a macro invoking itself while still running). #}
+    {% set attempts = 1 if raw_attempts < 1 else (5 if raw_attempts > 5 else raw_attempts) %}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=quiet VALUE={quiet}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=soft VALUE={soft}
-    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=attempts_remaining VALUE={attempts}
+    SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=attempts_total VALUE={attempts}
     M400
     G4 P{c.tool_detect_settle_ms|int}
     _VERIFY_TOOL_PRESENT_CHECK
-    _VERIFY_TOOL_PRESENT_RETRY
+    _VERIFY_TOOL_PRESENT_RETRY N=2
+    _VERIFY_TOOL_PRESENT_RETRY N=3
+    _VERIFY_TOOL_PRESENT_RETRY N=4
+    _VERIFY_TOOL_PRESENT_RETRY N=5
+    _VERIFY_TOOL_PRESENT_FINISH
 
 [gcode_macro _VERIFY_TOOL_PRESENT_CHECK]
 description: Inner - read absolute force after settle
@@ -147,20 +153,24 @@ gcode:
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_msg VALUE='"{ns.msg}"'
 
 [gcode_macro _VERIFY_TOOL_PRESENT_RETRY]
-description: Inner - re-settle and re-sample on fail until tool_detect_attempts exhausted; hard-raise only then when not SOFT
+description: Inner - sample N of VERIFY (no-op if already ok or attempts_total < N). Call sequentially from VERIFY, never from itself.
 gcode:
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
     {% set v = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
-    {% set remaining = v.attempts_remaining|int %}
-    {% if v.last_ok|int == 1 %}
-        # Pass - stop early
-    {% elif remaining > 1 %}
-        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=attempts_remaining VALUE={remaining - 1}
-        RESPOND MSG="VERIFY_TOOL_PRESENT: attempt failed ({'%.1f'|format(v.last_force_g|float)}g), retrying ({remaining - 1} left)"
+    {% set n = params.N|default(2)|int %}
+    {% if v.last_ok|int == 1 or v.attempts_total|int < n %}
+        # Skip
+    {% else %}
+        RESPOND MSG="VERIFY_TOOL_PRESENT: attempt failed ({'%.1f'|format(v.last_force_g|float)}g), retrying ({n}/{v.attempts_total|int})"
         G4 P{c.tool_detect_settle_ms|int}
         _VERIFY_TOOL_PRESENT_CHECK
-        _VERIFY_TOOL_PRESENT_RETRY
-    {% elif not v.soft|int %}
+    {% endif %}
+
+[gcode_macro _VERIFY_TOOL_PRESENT_FINISH]
+description: Inner - hard-raise after attempts exhausted when not SOFT
+gcode:
+    {% set v = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% if v.last_ok|int != 1 and not v.soft|int %}
         {action_raise_error(v.last_msg)}
     {% endif %}
 

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -93,8 +93,7 @@ gcode:
     {% set quiet = params.QUIET|default(0)|int %}
     {% set soft = params.SOFT|default(0)|int %}
     {% set raw_attempts = params.ATTEMPTS|default(c.tool_detect_attempts)|int %}
-    {# Clamp 1..5. Retries are sequential sibling calls (not nested self-calls -
-       Klipper forbids a macro invoking itself while still running). #}
+    {# Clamp 1..5. RETRY N= calls are sequential siblings, not nested self-calls. #}
     {% set attempts = 1 if raw_attempts < 1 else (5 if raw_attempts > 5 else raw_attempts) %}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=quiet VALUE={quiet}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=soft VALUE={soft}

--- a/macros/indx-helpers.cfg
+++ b/macros/indx-helpers.cfg
@@ -93,7 +93,7 @@ gcode:
     {% set quiet = params.QUIET|default(0)|int %}
     {% set soft = params.SOFT|default(0)|int %}
     {% set raw_attempts = params.ATTEMPTS|default(c.tool_detect_attempts)|int %}
-    {# Clamp 1..5. RETRY N= calls are sequential siblings, not nested self-calls. #}
+    # Clamp 1..5. RETRY N= calls are sequential siblings, not nested self-calls.
     {% set attempts = 1 if raw_attempts < 1 else (5 if raw_attempts > 5 else raw_attempts) %}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=quiet VALUE={quiet}
     SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=soft VALUE={soft}

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -59,9 +59,6 @@ variable_tool_detect_enabled: 1
 variable_tool_detect_min_force_g: 400.0
 variable_tool_detect_settle_ms: 800
 
-# Part cooling after a successful pickup (M106 S scale, 0-255). ~30%.
-variable_post_pickup_fan_s: 77
-
 gcode:
 
 #####################################################################
@@ -509,8 +506,6 @@ gcode:
         {% if params.TARGET|default(0)|float > 0 %}
             M104 S{params.TARGET|default(0)|float}
         {% endif %}
-        # Soft part-cooling after seat so the cold nozzle does not get blasted full-fan
-        M106 S{c.post_pickup_fan_s|int}
 
         # Record last - save active_tool and increment counter after physical pickup completes
         _RECORD_TOOLCHANGE TOOL={t}

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -49,6 +49,19 @@ variable_run_current: 0.6
 # printer.cfg rotation_distance is restored after every macro that issues E moves.
 variable_tc_rotation_distance: 5.7
 
+# --- Load-cell tool presence ---
+# Detect uses absolute grams vs empty-head reference: force_g + tare_force.
+# Z probing re-tares the host cell, so raw force_g alone is wrong after home/probe.
+# Cal may cinch to ~1600 g once; pickup uses full_lock_e only (no cinch like calibration).
+# Normal-lock absolute preload is often below 1600; min ~400 fails closed on empty.
+# Raise if false negatives; lower only with care (false positives heat an empty coil).
+variable_tool_detect_enabled: 1
+variable_tool_detect_min_force_g: 400.0
+variable_tool_detect_settle_ms: 800
+
+# Part cooling after a successful pickup (M106 S scale, 0-255). ~30%.
+variable_post_pickup_fan_s: 77
+
 gcode:
 
 #####################################################################
@@ -104,6 +117,12 @@ gcode:
     RESPOND MSG="  🔧 TOOLS:       {tp.tools|length} configured"
     RESPOND MSG="  📦 ACTIVE TOOL: {('T' ~ sv.active_tool if sv.active_tool|default(-1)|int >= 0 else 'NONE')}"
     RESPOND MSG="  🔄 TC COUNT:    {sv.toolchange_count|default(0)|int}"
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {% if vd.last_ok|int == 1 %}
+        RESPOND MSG="  ⚖️ TOOL DETECT: ok ({'%.1f'|format(vd.last_force_g|float)}g)"
+    {% elif vd.last_ok|int == 0 %}
+        RESPOND MSG="  ⚖️ TOOL DETECT: fail ({'%.1f'|format(vd.last_force_g|float)}g)"
+    {% endif %}
     RESPOND MSG="----------------------------------------"
     RESPOND MSG="  🛠️ INDX STATUS"
     RESPOND MSG="----------------------------------------"
@@ -430,33 +449,78 @@ gcode:
     _TC_LATCH_MOVE E={c.full_lock_e} F={c.latch_feedrate} I={c.run_current}
     _TC_RESTORE_ROTATION_DIST
 
-    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=0
-    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=0
+    # Confirm a tool is seated via latch preload before exit/heat/record.
+    # SOFT=1: only set last_ok (Jinja cannot read it in this same macro after the call).
+    {% if c.tool_detect_enabled|int %}
+        VERIFY_TOOL_PRESENT QUIET=1 SOFT=1
+    {% else %}
+        SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=last_ok VALUE=1
+    {% endif %}
+    _PICKUP_TOOL_FINISH TOOL={t} TARGET={params.TARGET|default(0)|float} RESTORE_Z={restore_z}
 
-    # Z hop-down is folded into _LINEAR_EXIT's Y-clearance sprint (non-blocking)
-    _LINEAR_EXIT RESTORE_Z={restore_z}
-    M400
+[gcode_macro _PICKUP_TOOL_FINISH]
+description: Inner - finish pickup after lock/detect. On failed detect: unlock empty head, exit dock, then error or pause.
+gcode:
+    {% set t = params.TOOL|int %}
+    {% set restore_z = params.RESTORE_Z|default("")|string %}
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
 
-    # Apply new tool offsets.
-    # Z = tool_z + global_z so the toolhead lands at the correct first-layer height.
-    # The babystep widget reflects this combined value; ADJUST_GLOBAL_Z/SYNC_GLOBAL_Z
-    # strip the tool_z component to expose the pure global adjustment.
-    {% set svv = printer.save_variables.variables %}
-    {% set tool_z = svv["t" ~ t ~ "_offset_z"]|default(0.0)|float %}
-    {% set global_z = svv.global_z_offset|default(0.0)|float %}
-    SET_GCODE_OFFSET X={svv["t"~t~"_offset_x"]|default(0.0)} Y={svv["t"~t~"_offset_y"]|default(0.0)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=1
+    {% if vd.last_ok|int == 0 %}
+        # Pickup locked but load cell saw no/low preload - unlock + exit BEFORE any
+        # raise. action_raise_error runs at Jinja eval time, so it must live in a
+        # follow-up macro or unlock never executes (stuck: latched tool, no active_tool).
+        _TC_SET_ROTATION_DIST
+        _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate} I={c.run_current}
+        _TC_RESTORE_ROTATION_DIST
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+        SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+        _LINEAR_EXIT RESTORE_Z={restore_z}
+        {% set printing = printer.print_stats.state|default("") == "printing" %}
+        {% if printing %}
+            # Mid-print: never action_raise_error (SD treats that as print error).
+            # User seats/locks T{t} by hand, then RESUME re-samples and syncs soft state.
+            SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_recheck VALUE=1
+            SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_tool VALUE={t}
+            SET_GCODE_VARIABLE MACRO=VERIFY_TOOL_PRESENT VARIABLE=pending_target VALUE={params.TARGET|default(0)|float}
+            RESPOND MSG="Tool detect failed mid-print. Seat and lock T{t} on the Smart Head by hand, then RESUME."
+            PAUSE
+        {% else %}
+            _PICKUP_TOOL_DETECT_FAIL
+        {% endif %}
+    {% else %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=0
+        SAVE_VARIABLE VARIABLE=toolhead_state VALUE=0
 
-    # Start heating only after tool is fully locked, exited dock, and offsets applied
-    {% if params.TARGET|default(0)|float > 0 %}
-        M104 S{params.TARGET|default(0)|float}
+        # Z hop-down is folded into _LINEAR_EXIT's Y-clearance sprint (non-blocking)
+        _LINEAR_EXIT RESTORE_Z={restore_z}
+        M400
+
+        # Apply new tool offsets.
+        # Z = tool_z + global_z so the toolhead lands at the correct first-layer height.
+        # The babystep widget reflects this combined value; ADJUST_GLOBAL_Z/SYNC_GLOBAL_Z
+        # strip the tool_z component to expose the pure global adjustment.
+        {% set svv = printer.save_variables.variables %}
+        {% set tool_z = svv["t" ~ t ~ "_offset_z"]|default(0.0)|float %}
+        {% set global_z = svv.global_z_offset|default(0.0)|float %}
+        SET_GCODE_OFFSET X={svv["t"~t~"_offset_x"]|default(0.0)} Y={svv["t"~t~"_offset_y"]|default(0.0)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=1
+
+        # Start heating only after tool is fully locked, exited dock, and offsets applied
+        {% if params.TARGET|default(0)|float > 0 %}
+            M104 S{params.TARGET|default(0)|float}
+        {% endif %}
+        # Soft part-cooling after seat so the cold nozzle does not get blasted full-fan
+        M106 S{c.post_pickup_fan_s|int}
+
+        # Record last - save active_tool and increment counter after physical pickup completes
+        _RECORD_TOOLCHANGE TOOL={t}
     {% endif %}
 
-    # Record last — save active_tool and increment counter after physical pickup completes
-    _RECORD_TOOLCHANGE TOOL={t}
-
-#####################################################################
-#  6. HELPER MACROS
-#####################################################################
+[gcode_macro _PICKUP_TOOL_DETECT_FAIL]
+description: Inner - raise after unlock/exit on idle pickup detect fail (must be separate macro).
+gcode:
+    {% set vd = printer["gcode_macro VERIFY_TOOL_PRESENT"] %}
+    {action_raise_error(vd.last_msg)}
 
 [gcode_macro _RECORD_TOOLCHANGE]
 description: Inner — saves active_tool and increments the toolchange counter after every successful pickup

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -38,7 +38,10 @@ variable_wiggle_feedrate: 2500
 variable_dock_feedrate: 3000
 variable_latch_feedrate: 1500
 variable_peel_feedrate: 3000
-variable_engage_feedrate: 2500
+# Fixed (not MODE-scaled) feeds for the final pickup Y approach onto the tool.
+# approach = clearance -> trigger; engage = trigger -> dock (~trigger_offset mm).
+variable_approach_feedrate: 2500
+variable_engage_feedrate: 1800
 
 # --- Extruder current (amps) ---
 variable_squeeze_current: 0.2
@@ -55,9 +58,12 @@ variable_tc_rotation_distance: 5.7
 # Cal may cinch to ~1600 g once; pickup uses full_lock_e only (no cinch like calibration).
 # Normal-lock absolute preload is often below 1600; min ~400 fails closed on empty.
 # Raise if false negatives; lower only with care (false positives heat an empty coil).
+# VERIFY samples on the dock (peel-before-detect deferred). attempts = total
+# samples per call (min 1), each separated by settle_ms; stop early on pass.
 variable_tool_detect_enabled: 1
 variable_tool_detect_min_force_g: 400.0
 variable_tool_detect_settle_ms: 800
+variable_tool_detect_attempts: 3
 
 gcode:
 
@@ -424,8 +430,9 @@ gcode:
     _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
     SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
-    # Sprint to trigger line
-    _TC_G0 Y={"%.3f"|format(trigger_y)}
+    # Fixed-feed approach onto the tool (not MODE-scaled _TC_G0) so MODE_CUSTOM
+    # does not slam into the trigger line / seating slide.
+    G1 Y{"%.3f"|format(trigger_y)} F{c.approach_feedrate}
 
     # Latch moves run through INDX_EXTRUDER_MOVE so pickup works on a cold tool
     # without heating it. INDX_EXTRUDER_MOVE moves are inherently relative.
@@ -439,7 +446,7 @@ gcode:
         SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
     {% endif %}
 
-    # Engagement slide to dock
+    # Engagement slide to dock (short seat at engage_feedrate)
     G1 Y{"%.3f"|format(dock_y)} F{c.engage_feedrate}
 
     # Lock the tool

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -38,8 +38,10 @@ variable_wiggle_feedrate: 2500
 variable_dock_feedrate: 3000
 variable_latch_feedrate: 1500
 variable_peel_feedrate: 3000
-# Fixed (not MODE-scaled) feeds for the final pickup Y approach onto the tool.
-# approach = clearance -> trigger; engage = trigger -> dock (~trigger_offset mm).
+# Fixed (not MODE-scaled) feeds for the final Y approach onto the tool.
+# park_approach / approach = clearance -> trigger (park / pickup).
+# engage = trigger -> dock (~trigger_offset mm) on pickup.
+variable_park_approach_feedrate: 2500
 variable_approach_feedrate: 2500
 variable_engage_feedrate: 1800
 
@@ -77,6 +79,8 @@ variable_accel_mult: 0.7
 variable_speed_mult: 0.7
 variable_toolhead_state: 0 # 0=Locked, 2=Open
 variable_rotation_dist_overridden: 0
+# Set by [homing_override] so CHANGE_TOOL/PARK_TOOL do not re-enter G28 mid-home.
+variable_homing_busy: 0
 gcode:
 
 [delayed_gcode INIT_STATE]
@@ -311,8 +315,9 @@ gcode:
         {% endif %}
 
         {% if act != t %}
-            # 0. Home if not already homed
-            {% if "xyz" not in printer.toolhead.homed_axes %}
+            # 0. Home if not already homed (skip when called from [homing_override])
+            {% set busy = printer["gcode_macro _TOOLCHANGE_VARS"].homing_busy|default(0)|int %}
+            {% if not busy and "xyz" not in printer.toolhead.homed_axes %}
                 G28
             {% endif %}
 
@@ -371,8 +376,9 @@ gcode:
     {% set zhop = params.ZHOP|default(0.0)|float %}
 
     {% if act != -1 %}
-        # Home if not already homed
-        {% if "xyz" not in printer.toolhead.homed_axes %}
+        # Home if not already homed (skip when called from [homing_override])
+        {% set busy = printer["gcode_macro _TOOLCHANGE_VARS"].homing_busy|default(0)|int %}
+        {% if not busy and "xyz" not in printer.toolhead.homed_axes %}
             G28
         {% endif %}
 
@@ -392,9 +398,9 @@ gcode:
         _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
         SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
-        # High-speed sprint to trigger line
-        _TC_G0 Y={"%.3f"|format(trigger_y)}
-        
+        # Fixed-feed approach to trigger (not MODE-scaled _TC_G0)
+        G1 Y{"%.3f"|format(trigger_y)} F{c.park_approach_feedrate}
+
         {% if st == 0 %}
             _SYNC_UNLOCK_DANCE DOCK_Y={dock_y}
             SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -54,6 +54,11 @@ variable_probe_y:          -1.0   # set to bed centre Y, or -1 to auto-detect
 variable_probe_fuzz:         2.0
 variable_probe_z_clearance: 10.0
 
+# ── Dock approach direction ──────────────────────────────────────────────────
+#  dock_dir = Y sign into the dock: -1 front (min Y), +1 rear (max Y).
+#             Used by homing clearance checks before X.
+variable_dock_dir: -1
+
 # ── Trigger offset ───────────────────────────────────────────────────────────
 #  trigger_offset = distance (mm) from dock_y to the trigger line.
 #                   trigger_y is auto-derived as: dock_y + trigger_offset

--- a/macros/print_start.cfg
+++ b/macros/print_start.cfg
@@ -1,0 +1,56 @@
+#####################################################################
+#  Example PRINT_START for INDX + OrcaSlicer
+#
+#  Include from printer.cfg:
+#    [include print_start.cfg]
+#
+#  Orca start G-code (example):
+#    PRINT_START BED_TEMP=[bed_temperature_initial_layer_single] \
+#                EXTRUDER_TEMP={first_layer_temperature[initial_tool]} \
+#                TOOL=[initial_tool]
+#
+#  Requires KAMP Smart_Park.cfg. Height is set via _KAMP_Settings
+#  (stock SMART_PARK has no Z= param).
+#
+#  Sequence notes:
+#  - Pick the print's initial TOOL before G28 Z so Z homes with that
+#    nozzle (any-tool Z home). CAL_Z offsets stay T0-relative.
+#  - Soft-heat (WAIT_TEMP) before first G28 Z / tilt.
+#####################################################################
+
+[gcode_macro PRINT_START]
+description: Home Y/X, pick initial tool for Z, tilt, SMART_PARK, heat
+gcode:
+    {% set bed_temp = params.BED_TEMP|float %}
+    {% set extruder_temp = params.EXTRUDER_TEMP|float %}
+    {% set tool = params.TOOL|default(0)|int %}
+    {% set wait_temp = params.WAIT_TEMP|default(150)|float %}
+
+    M140 S{bed_temp}
+
+    G28 Y
+    G28 X
+
+    # Fake-home Z so CHANGE_TOOL can Z-hop; real soft G28 Z comes after heat.
+    # homing_busy also blocks CHANGE_TOOL's auto full-G28 while Z is unprobed.
+    {% if "z" not in printer.toolhead.homed_axes %}
+        SET_KINEMATIC_POSITION Z=0 SET_HOMED=Z
+    {% endif %}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=1
+    CHANGE_TOOL TOOL={tool}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+
+    M104 S{wait_temp} # after first tool pick or error if no tool loaded.
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={wait_temp - 3} MAXIMUM={wait_temp + 3}
+    G28 Z
+    SAFE_Z_TILT_ADJUST
+
+    # KAMP SMART_PARK reads smart_park_height; Z= is ignored
+    SET_GCODE_VARIABLE MACRO=_KAMP_Settings VARIABLE=smart_park_height VALUE=0.4
+    SMART_PARK
+
+    M190 S{bed_temp}
+    # BED_MESH_CALIBRATE ADAPTIVE=1
+    M104 S{extruder_temp}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={extruder_temp - 3} MAXIMUM={extruder_temp + 3}
+    LINE_PURGE


### PR DESCRIPTION
# feat: load-cell tool detection and latch helpers

## Summary

Adds `macros/indx-helpers.cfg` for latch helpers and load-cell tool presence.

The helpers aid users in recovering from awkward states.

Tool presence detection fixes the fact that the current macros don't maintain correct tool state. They also provide a means to pause / resume printing when a pickup fails, rather than erroring out.

**Helpers** (in place, alter state):

- `INDX_LOCK` / `INDX_UNLOCK`
- `INDX_FORCE_STATE ACTIVE_TOOL=<n|-1>` - soft-state only

**Tool presence:**

- `VERIFY_TOOL_PRESENT` - manual seat check
- Pickup runs detect automatically after latch lock
- Mid-print fail -> `PAUSE`, user can run `CHANGE_TOOL TOOL=<n>` or seat tool by hand, then `RESUME`
- Idle fail -> Error

Requires a calibrated `[load_cell_probe]` (`CALIBRATE_LOAD_CELL` / `CALIBRATE_LOAD_CELL_APPLY`).

## Files

| File | Change |
| ---- | ------ |
| `macros/indx-helpers.cfg` | **New** - helpers + verify + RESUME recovery |
| `macros/indx-tc-macros.cfg` | Detect constants; pickup calls verify; fail paths |

## Include order

```ini
[include indx.cfg]
[include indx-tc-macros.cfg]
[include indx-cal.cfg]
[include indx-helpers.cfg]
```