### PR TITLE
fix: macros - clear XY gcode offsets before dock approach

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -367,8 +367,8 @@ gcode:
         # Z-hop up is folded into this first XY move (non-blocking: simultaneous axes)
         {% set hop_z = printer.gcode_move.gcode_position.z + zhop %}
         G90
+        SET_GCODE_OFFSET X=0.0 Y=0.0
         _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
-        SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
         # High-speed sprint to trigger line
         _TC_G0 Y={"%.3f"|format(trigger_y)}
@@ -405,8 +405,8 @@ gcode:
     # When act==-1 (no park), fold the Z hop-up into this first XY move
     {% set hop_z = printer.gcode_move.gcode_position.z + zhop %}
     G90
+    SET_GCODE_OFFSET X=0.0 Y=0.0
     _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
-    SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
     # Sprint to trigger line
     _TC_G0 Y={"%.3f"|format(trigger_y)}


### PR DESCRIPTION
# fix: macros - clear XY gcode offsets before dock approach

## Summary

- Clear per-tool XY `SET_GCODE_OFFSET` **before** the first dock approach move in `PARK_TOOL` and `_PICKUP_TOOL`

## Problem

Park and pickup previously did:

1. `_TC_G0 X={tool.x} Y={clearance_y}` while live XY offsets were still active
2. `SET_GCODE_OFFSET X=0 Y=0 MOVE=1`
3. Y-only sprint to `trigger_y` / engage to `dock_y`

With a non-zero `tN_offset_x`, step 1 drives the head to the wrong physical X. `MOVE=1` then causes a move of `tN_offset_x`. So the head ends up at `tool.x - tN_offset_x` instead of `tool.x`.

## Files

| File | Change |
| ---- | ------ |
| `macros/indx-tc-macros.cfg` | Reorder XY offset clear before dock approach in `PARK_TOOL` and `_PICKUP_TOOL` |

## Test plan

- [x] With non-zero `t1_offset_x` (e.g. 0.5 mm), run `CHANGE_TOOL TOOL=1` from a print position and confirm the first dock approach ends at physical X = `tool.x` for T1, not `tool.x - offset_x`
