### PR TITLE
fix: macros - use correct TMC chopper field on MODE_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,7 +1277,7 @@ Tool change motion speed and acceleration are controlled by three preset modes: 
 
 **Sport** uses the full `max_velocity` and `max_accel` from your `printer.cfg`. This gives the fastest possible toolchange times for your specific printer. Make sure your configured limits are within what your printer can actually handle; if `max_velocity` or `max_accel` are set too high, Sport mode will expose that immediately. Input shaper should be tuned before running Sport; without it, high-acceleration toolchange moves can cause the steppers to lose steps.
 
-Mode switching also sets StealthChop or SpreadCycle on every configured XY TMC driver (`tmc2208`, `tmc2209`, `tmc2130`, `tmc2240`, or `tmc5160`). On AWD setups, that includes `stepper_x1` and `stepper_y1` when present. The driver type is detected once at boot from your `printer.cfg`.
+Mode switching also sets StealthChop or SpreadCycle on every configured XY TMC driver (`tmc2208`, `tmc2209`, `tmc2130`, `tmc2240`, or `tmc5160`). On AWD setups, that includes `stepper_x1` and `stepper_y1` when present. Each driver is read from your `printer.cfg` individually, so mixed driver setups are handled correctly. If none of your XY steppers use a supported driver, the mode still changes speed and acceleration and INDX reports that the chopper mode was left untouched.
 
 The active mode persists across reboots. To change it, run the macro from the console or add it to your start G-code:
 

--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,8 @@ Tool change motion speed and acceleration are controlled by three preset modes: 
 
 **Sport** uses the full `max_velocity` and `max_accel` from your `printer.cfg`. This gives the fastest possible toolchange times for your specific printer. Make sure your configured limits are within what your printer can actually handle; if `max_velocity` or `max_accel` are set too high, Sport mode will expose that immediately. Input shaper should be tuned before running Sport; without it, high-acceleration toolchange moves can cause the steppers to lose steps.
 
+Mode switching also sets StealthChop or SpreadCycle on every configured XY TMC driver (`tmc2208`, `tmc2209`, `tmc2130`, `tmc2240`, or `tmc5160`). On AWD setups, that includes `stepper_x1` and `stepper_y1` when present. The driver type is detected once at boot from your `printer.cfg`.
+
 The active mode persists across reboots. To change it, run the macro from the console or add it to your start G-code:
 
 ```gcode

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -61,6 +61,8 @@ variable_accel_mult: 0.7
 variable_speed_mult: 0.7
 variable_toolhead_state: 0 # 0=Locked, 2=Open
 variable_rotation_dist_overridden: 0
+# XY TMC section prefix detected at boot (e.g. tmc2209, tmc5160). Empty = skip chopper writes.
+variable_tmc_prefix: ""
 gcode:
 
 [delayed_gcode INIT_STATE]
@@ -87,6 +89,23 @@ gcode:
     # accurately reflects the physical position across restarts.
     # Defaults to 0 (Locked) on first boot before any toolchange has been recorded.
     SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE={sv.toolhead_state|default(0)|int}
+
+    # Detect XY TMC driver family once so MODE_* can write the correct chopper field
+    # (en_spreadcycle on 2208/2209, en_pwm_mode on 2130/2240/5160) including AWD x1/y1.
+    {% set cfg = printer.configfile.settings %}
+    {% set tmc_prefixes = ["tmc2209", "tmc2208", "tmc2240", "tmc2130", "tmc5160"] %}
+    {% set xy_steppers = ["stepper_x", "stepper_x1", "stepper_y", "stepper_y1"] %}
+    {% set tmc_ns = namespace(prefix="") %}
+    {% for stepper in xy_steppers %}
+        {% if tmc_ns.prefix == "" %}
+            {% for prefix in tmc_prefixes %}
+                {% if tmc_ns.prefix == "" and (prefix ~ " " ~ stepper) in cfg %}
+                    {% set tmc_ns.prefix = prefix %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=tmc_prefix VALUE='"{tmc_ns.prefix}"'
 
     MODE_{sv.tc_mode|default("NORMAL")|upper}
     TOOL_STATUS
@@ -171,8 +190,26 @@ gcode:
 
     # 2. Write Acoustic Modes to TMC Stepper Hardware (Global & Persistent)
     # 0 = StealthChop (Quiet/Hot), 1 = SpreadCycle (Loud/Powerful)
-    SET_TMC_FIELD STEPPER=stepper_x FIELD=en_spreadcycle VALUE={params.C|int}
-    SET_TMC_FIELD STEPPER=stepper_y FIELD=en_spreadcycle VALUE={params.C|int}
+    # en_spreadcycle is 2208/2209 only; 2130/2240/5160 use inverted en_pwm_mode.
+    {% set tmc_prefix = printer["gcode_macro _TOOLCHANGE_VARS"].tmc_prefix %}
+    {% if tmc_prefix %}
+        {% set c = params.C|int %}
+        {% set cfg = printer.configfile.settings %}
+        {% set xy_steppers = ["stepper_x", "stepper_x1", "stepper_y", "stepper_y1"] %}
+        {% set ns = namespace(field="", value=0) %}
+        {% if tmc_prefix in ["tmc2208", "tmc2209"] %}
+            {% set ns.field = "en_spreadcycle" %}
+            {% set ns.value = c %}
+        {% else %}
+            {% set ns.field = "en_pwm_mode" %}
+            {% set ns.value = 1 - c %}
+        {% endif %}
+        {% for stepper in xy_steppers %}
+            {% if (tmc_prefix ~ " " ~ stepper) in cfg %}
+    SET_TMC_FIELD STEPPER={stepper} FIELD={ns.field} VALUE={ns.value}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
     # Restore extruder current to printer.cfg value (ensures mode switch doesn't leave wrong current)
     _RESTORE_EXTRUDER_CURRENT
 

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -61,8 +61,6 @@ variable_accel_mult: 0.7
 variable_speed_mult: 0.7
 variable_toolhead_state: 0 # 0=Locked, 2=Open
 variable_rotation_dist_overridden: 0
-# XY TMC section prefix detected at boot (e.g. tmc2209, tmc5160). Empty = skip chopper writes.
-variable_tmc_prefix: ""
 gcode:
 
 [delayed_gcode INIT_STATE]
@@ -89,23 +87,6 @@ gcode:
     # accurately reflects the physical position across restarts.
     # Defaults to 0 (Locked) on first boot before any toolchange has been recorded.
     SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE={sv.toolhead_state|default(0)|int}
-
-    # Detect XY TMC driver family once so MODE_* can write the correct chopper field
-    # (en_spreadcycle on 2208/2209, en_pwm_mode on 2130/2240/5160) including AWD x1/y1.
-    {% set cfg = printer.configfile.settings %}
-    {% set tmc_prefixes = ["tmc2209", "tmc2208", "tmc2240", "tmc2130", "tmc5160"] %}
-    {% set xy_steppers = ["stepper_x", "stepper_x1", "stepper_y", "stepper_y1"] %}
-    {% set tmc_ns = namespace(prefix="") %}
-    {% for stepper in xy_steppers %}
-        {% if tmc_ns.prefix == "" %}
-            {% for prefix in tmc_prefixes %}
-                {% if tmc_ns.prefix == "" and (prefix ~ " " ~ stepper) in cfg %}
-                    {% set tmc_ns.prefix = prefix %}
-                {% endif %}
-            {% endfor %}
-        {% endif %}
-    {% endfor %}
-    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=tmc_prefix VALUE='"{tmc_ns.prefix}"'
 
     MODE_{sv.tc_mode|default("NORMAL")|upper}
     TOOL_STATUS
@@ -190,25 +171,25 @@ gcode:
 
     # 2. Write Acoustic Modes to TMC Stepper Hardware (Global & Persistent)
     # 0 = StealthChop (Quiet/Hot), 1 = SpreadCycle (Loud/Powerful)
-    # en_spreadcycle is 2208/2209 only; 2130/2240/5160 use inverted en_pwm_mode.
-    {% set tmc_prefix = printer["gcode_macro _TOOLCHANGE_VARS"].tmc_prefix %}
-    {% if tmc_prefix %}
-        {% set c = params.C|int %}
-        {% set cfg = printer.configfile.settings %}
-        {% set xy_steppers = ["stepper_x", "stepper_x1", "stepper_y", "stepper_y1"] %}
-        {% set ns = namespace(field="", value=0) %}
-        {% if tmc_prefix in ["tmc2208", "tmc2209"] %}
-            {% set ns.field = "en_spreadcycle" %}
-            {% set ns.value = c %}
-        {% else %}
-            {% set ns.field = "en_pwm_mode" %}
-            {% set ns.value = 1 - c %}
-        {% endif %}
-        {% for stepper in xy_steppers %}
-            {% if (tmc_prefix ~ " " ~ stepper) in cfg %}
-    SET_TMC_FIELD STEPPER={stepper} FIELD={ns.field} VALUE={ns.value}
+    # The field is driver specific: 2208/2209 use en_spreadcycle, while 2130/2240/5160
+    # use en_pwm_mode with the inverted meaning (1 = StealthChop). Detected per stepper
+    # so mixed driver and AWD (stepper_x1/y1) machines are all covered.
+    {% set c = params.C|int %}
+    {% set cfg = printer.configfile.settings %}
+    {% set drivers = {"tmc2209": "en_spreadcycle", "tmc2208": "en_spreadcycle",
+                      "tmc2240": "en_pwm_mode", "tmc2130": "en_pwm_mode",
+                      "tmc5160": "en_pwm_mode"} %}
+    {% set ns = namespace(found=false) %}
+    {% for stepper in ["stepper_x", "stepper_x1", "stepper_y", "stepper_y1"] %}
+        {% for prefix, field in drivers.items() %}
+            {% if (prefix ~ " " ~ stepper) in cfg %}
+                {% set ns.found = true %}
+    SET_TMC_FIELD STEPPER={stepper} FIELD={field} VALUE={c if field == "en_spreadcycle" else 1 - c}
             {% endif %}
         {% endfor %}
+    {% endfor %}
+    {% if not ns.found %}
+    RESPOND MSG="INDX: no supported XY TMC driver found, speed mode set without changing StealthChop/SpreadCycle"
     {% endif %}
     # Restore extruder current to printer.cfg value (ensures mode switch doesn't leave wrong current)
     _RESTORE_EXTRUDER_CURRENT


### PR DESCRIPTION
## Summary
- Detect the XY TMC driver family once at boot and store it on `_TOOLCHANGE_VARS`
- Write `en_spreadcycle` (TMC2208/2209) or inverted `en_pwm_mode` (2130/2240/5160) from `MODE_*`, including AWD `stepper_x1`/`y1` when present
- Document supported XY TMC drivers and AWD coverage under Speed & Acceleration

Fixes #30