### PR TITLE
fix: macros - Don't discard Z offset adjustment

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -765,15 +765,19 @@ gcode:
     # homing_origin.z = tool_z + global_z. The base command subtracts homing_origin.z from
     # [load_cell_probe] z_offset, so we must temporarily set it to only global_z first.
     # After baking, restore homing_origin.z to tool_z so the active tool stays correct.
+    # Use the live babystep (homing_origin.z - tool_z) so Mainsail/Fluidd Apply works
+    # without a prior SYNC_GLOBAL_Z; save_variables alone is not updated by those UIs.
     {% set svv = printer.save_variables.variables %}
     {% set act = svv.active_tool|default(-1)|int %}
     {% set tool_z = svv["t" ~ act ~ "_offset_z"]|default(0.0)|float if act >= 0 else 0.0 %}
-    {% set global_z = svv.global_z_offset|default(0.0)|float %}
+    {% set global_z = printer.gcode_move.homing_origin.z|float - tool_z %}
     SET_GCODE_OFFSET Z='{"%.3f"|format(global_z)}'
     _Z_OFFSET_APPLY_PROBE_BASE
     SET_GCODE_OFFSET Z='{"%.3f"|format(tool_z)}'
     SAVE_VARIABLE VARIABLE=global_z_offset VALUE=0.0
-    RESPOND MSG="Global Z baked into [load_cell_probe] z_offset. Run SAVE_CONFIG to persist."
+    {% if global_z %}
+        RESPOND MSG="Global Z baked into [load_cell_probe] z_offset. Run SAVE_CONFIG to persist."
+    {% endif %}
 
 
 #####################################################################


### PR DESCRIPTION
## Summary

- Derive the global Z to bake from the live babystep (`homing_origin.z - tool_z`), matching `SYNC_GLOBAL_Z`, so Mainsail/Fluidd Apply works without a prior sync
- Only print the bake success message when there is a non-zero global Z to apply

## Problem

`Z_OFFSET_APPLY_PROBE` wraps the stock probe command so only the global component of `homing_origin.z` is written into `[load_cell_probe] z_offset` (not per-tool Z).

It previously read `save_variables.global_z_offset` and then ran `SET_GCODE_OFFSET Z={global_z}` before the builtin. Mainsail/Fluidd babystepping only changes live `homing_origin.z`; it does not update `global_z_offset`.


Example: T1 active with `t1_offset_z = 0.200`, probe `z_offset = 1.000`. You babystep **+0.050** in Mainsail.

1. Mainsail runs `SET_GCODE_OFFSET` so live `homing_origin.z` becomes `0.250` (`0.200` tool + `0.050` babystep). `save_variables.global_z_offset` stays `0.000`.
2. When saving the offset, Mainsail runs `Z_OFFSET_APPLY_PROBE`.
3. Macro reads `global_z = svv.global_z_offset` which is almost always the same as `global_z = 0.000`.
4. It runs `SET_GCODE_OFFSET Z=0.000`, which **replaces** the live offset. The +0.050 babystep is removed, and now `homing_origin.z` is `0`.
5. `_Z_OFFSET_APPLY_PROBE_BASE` reads `homing_origin.z`, sees `0`, and prints `Nothing to do: Z Offset is 0`. Probe config is unchanged.
6. The macro then runs `SET_GCODE_OFFSET Z=0.200` (from `tN_offset_z`) and clears `global_z_offset` to `0`.
7. Net result, UI adjustment is discarded, probe `z_offset` is unchanged, and the success line is misleading.

The fixed macro instead sets `global_z = homing_origin.z - tool_z` to `0.050` before those steps, so the builtin receives the babystep and can subtract it from the probe.