### PR TITLE
fix: Don't set temperature to 0 during extrusion.

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -304,9 +304,9 @@ gcode:
             {% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
             SET_VELOCITY_LIMIT VELOCITY={max_v * v.speed_mult} ACCEL={max_a * v.accel_mult}
 
-            # 3. Capture the target temperature. Coil-off waits until PARK_TOOL
-            #    has drained leftover print G1s and queued the first park travel.
-            #    M104 is not a move; issuing it here would cut heat mid-line.
+            # 3. Capture the target temperature. Coil-off is in PARK_TOOL after
+            #    the head is at trigger Y (M104 is not a move; issuing it here
+            #    would cut heat during leftover print G1s).
             {% set target_temp = printer.extruder.target | float %}
 
             # 4. Z-Sync before moving
@@ -325,8 +325,6 @@ gcode:
             # 6. Physical tool swap
             {% if act != -1 %}
                 PARK_TOOL ZHOP={zhop}
-            {% else %}
-                M104 S0
             {% endif %}
 
             # Pass ZHOP only when there was no park (act==-1): _PICKUP_TOOL then folds
@@ -357,10 +355,6 @@ gcode:
             G28
         {% endif %}
 
-        # Drain leftover print moves while still hot, then leave the print
-        # before M104. A long queued G1 would otherwise keep extruding cold.
-        M400
-
         # Resolve this tool's dock geometry
         {% set tool = tp.tools[act] %}
         {% set dock_y = tool.dock_y %}
@@ -372,11 +366,13 @@ gcode:
         {% set hop_z = printer.gcode_move.gcode_position.z + zhop %}
         G90
         _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
-        M104 S0
         SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
-        # High-speed sprint to trigger line
+        # High-speed sprint to trigger line. 
         _TC_G0 Y={"%.3f"|format(trigger_y)}
+        # run M400 here so we dont dwell over the print, and to force M104 to not cut heat mid-print moves
+        M400
+        M104 S0
         
         {% if st == 0 %}
             _SYNC_UNLOCK_DANCE DOCK_Y={dock_y}

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -304,10 +304,11 @@ gcode:
             {% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
             SET_VELOCITY_LIMIT VELOCITY={max_v * v.speed_mult} ACCEL={max_a * v.accel_mult}
 
-            # 3. Capture the target temperature then turn off the heater before any movement
+            # 3. Capture the target temperature. Coil-off waits until PARK_TOOL
+            #    has drained leftover print G1s and queued the first park travel.
+            #    M104 is not a move; issuing it here would cut heat mid-line.
             {% set target_temp = printer.extruder.target | float %}
-            M104 S0
-            
+
             # 4. Z-Sync before moving
             {% set svv = printer.save_variables.variables %}
             {% if act >= 0 %}
@@ -324,6 +325,8 @@ gcode:
             # 6. Physical tool swap
             {% if act != -1 %}
                 PARK_TOOL ZHOP={zhop}
+            {% else %}
+                M104 S0
             {% endif %}
 
             # Pass ZHOP only when there was no park (act==-1): _PICKUP_TOOL then folds
@@ -354,8 +357,9 @@ gcode:
             G28
         {% endif %}
 
-        # SAFETY: Heater off before any dock approach
-        M104 S0
+        # Drain leftover print moves while still hot, then leave the print
+        # before M104. A long queued G1 would otherwise keep extruding cold.
+        M400
 
         # Resolve this tool's dock geometry
         {% set tool = tp.tools[act] %}
@@ -368,6 +372,7 @@ gcode:
         {% set hop_z = printer.gcode_move.gcode_position.z + zhop %}
         G90
         _TC_G0 X={tool.x} Y={"%.3f"|format(clearance_y)} {% if zhop > 0 %}Z={"%.3f"|format(hop_z)}{% endif %}
+        M104 S0
         SET_GCODE_OFFSET X=0.0 Y=0.0 MOVE=1
 
         # High-speed sprint to trigger line


### PR DESCRIPTION
## Summary

Klipper reads the next command(s) before the nozzle has finished the last move. `M104` is not a move, so it runs immediately.

Main currently turns runs `M104` at the start of `CHANGE_TOOL`. The printer can still be extruding when heat is cut. This is especially bad if the last print command was a long straight move determined by a single command.

## Changes
This PR leaves heat on through leftover print moves and the park travel. At trigger Y it waits for those moves to finish (`M400`), then `M104 S0` before releasing the tool. The `M400` blocks execution of the `M104` until preceeding commands have all completed.

You could move the `M400` and `M104 S0` to the very beginning of `PARK_TOOL` to have more time cooling before release, but I found that this tends to lead to a slight dwell of the nozzle on the print.