### PR TITLE
index-cal cfg updates & fixes

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -78,7 +78,7 @@ gcode:
 #
 #####################################################################
 
-[gcode_macro CAL_01_SET_CAMERA_REF]
+[gcode_macro CAL_ONE_SET_CAMERA_REF]
 description: Step 1 — Centre T0 in camera crosshair and save as reference point
 gcode:
     {% set pos = printer.toolhead.position %}
@@ -87,7 +87,7 @@ gcode:
     SAVE_VARIABLE VARIABLE=cam_pos_z VALUE='{"%.3f"|format(pos.z)}'
     RESPOND MSG="Camera reference saved at T0 position (X={'%.3f'|format(pos.x)} Y={'%.3f'|format(pos.y)} Z={'%.3f'|format(pos.z)})."
 
-[gcode_macro CAL_02_PREP_TOOL_CAL]
+[gcode_macro CAL_TWO_PREP_TOOL_CAL]
 description: Step 2 — Pick up tool N and move to camera position for alignment
 gcode:
     {% set t = params.TOOL|default(-1)|int %}
@@ -101,7 +101,7 @@ gcode:
         RESPOND TYPE=error MSG="Usage: CAL_02_PREP_TOOL_CAL TOOL=1"
     {% endif %}
 
-[gcode_macro CAL_03_SAVE_XY_OFFSET]
+[gcode_macro CAL_THREE_SAVE_XY_OFFSET]
 description: Step 3 — Calculate XY offset from current position and save
 gcode:
     {% set svv = printer.save_variables.variables %}
@@ -183,9 +183,9 @@ gcode:
 [gcode_macro CAL_Z]
 description: Convergent Z probe (SD window + fuzzing) then median samples — saves Z offsets relative to T0
 variable_probe_location:  "rear"   # "center" | "rear" | "front" | "left" | "right"
-variable_edge_inset:         5.0   # mm from bed edge to near edge of fuzz circle
+variable_edge_inset:         70.0  # mm from bed edge to near edge of fuzz circle
 variable_probe_speed:        3.0   # normal probe speed mm/s (halved after 2 fuzz moves)
-variable_probe_retract:      1.0   # Z retract between convergence/sample probes (mm, relative)
+variable_probe_retract:      10.0  # Z retract between convergence/sample probes (mm, relative)
 variable_toolchange_z:      20.0   # minimum Z before each CHANGE_TOOL (nozzle clearance, mm)
 variable_sample_count:         5   # final clean probes per tool — median saved as result
 gcode:
@@ -940,20 +940,38 @@ gcode:
 description: Load cell calibration step 1 of 2 - run before first Z homing with NO tool mounted. Homes X and Y, opens the latch (soft-state Open), and tares the empty head, then prompts you to seat a tool and run CALIBRATE_LOAD_CELL_APPLY.
 gcode:
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
-    # Home X and Y - Z is NOT homed yet; Z homing needs the calibrated load cell.
-    G28 X Y
-    LOAD_CELL_CALIBRATE
-    # Open the latch so a passive tool can be seated by hand
-    _TC_SET_ROTATION_DIST
-    _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate}
-    _TC_RESTORE_ROTATION_DIST
-    M400
-    G4 P500
-    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
-    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
-    # Tare the empty head
-    TARE
-    RESPOND MSG="Load cell tared (empty head). Seat a passive tool on the Smart Head by hand - the tool MUST BE EMPTY (no filament loaded). Then run: CALIBRATE_LOAD_CELL_APPLY GRAMS=1600"
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+    {% set st = printer["gcode_macro _TOOLCHANGE_VARS"].toolhead_state|int %}
+
+    {% if act == -1 %}
+        # Home X and Y — Z is NOT homed yet; Z homing needs the calibrated load cell.
+        {% if "xy" not in printer.toolhead.homed_axes %}
+            G28 X Y
+    
+        {% else %}
+            G0 X{printer.toolhead.axis_maximum.x|float / 2} Y{printer.toolhead.axis_maximum.y|float / 2} F3000
+        {% endif %}
+
+        LOAD_CELL_CALIBRATE
+
+        # Open the latch so a passive tool can be seated by hand
+        {% if st == 0 %}
+            _TC_SET_ROTATION_DIST
+            _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate}
+            _TC_RESTORE_ROTATION_DIST
+            M400
+            G4 P500
+            SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+            SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+        {% endif %}
+
+        # Tare the empty head
+        TARE
+        RESPOND MSG="Load cell tared (empty head). Seat a passive tool on the Smart Head by hand - the tool MUST BE EMPTY (no filament loaded). Then run: CALIBRATE_LOAD_CELL_APPLY GRAMS=1600"
+
+    {% else %}
+        {action_raise_error("Tool appears to be loaded, remove & try again.")}
+    {% endif %}
 
 [gcode_macro CALIBRATE_LOAD_CELL_APPLY]
 description: Load cell calibration step 2 of 2 - with a tool seated by hand, locks for the force sample, calibrates against GRAMS (default 1600), then unlocks (soft-state Open, no active_tool claim). Run SAVE_CONFIG after.
@@ -980,3 +998,28 @@ gcode:
     SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
     SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
     RESPOND MSG="Load cell calibrated against {grams|int} g. Latch unlocked. Remove the tool by hand, then run SAVE_CONFIG."
+
+[gcode_macro MANUAL_TOOL_REMOVE]
+description: ⚠️ Opens toolhead latch for tool removal by hand & resets toolhead macro status to OPEN & EMPTY - USE WITH CAUTION! ⚠️
+gcode:
+    {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
+
+    _TC_SET_ROTATION_DIST
+    _TC_LATCH_MOVE E={c.full_open_e} F={c.latch_feedrate}
+    _TC_RESTORE_ROTATION_DIST
+    M400
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=active_tool VALUE=-1
+    RESPOND MSG="⚠️ WARNING! Toolhead latch OPEN! Be sure to REMOVE any tools by hand!!! The toolhead status & active tool have been RESET to OPEN & EMPTY!!"
+
+[gcode_macro MANUAL_TOOLHEAD_RESET]
+description: ⚠️ Resets toolhead macro status to OPEN & EMPTY - USE WITH CAUTION! ⚠️
+gcode:
+
+    SAVE_VARIABLE VARIABLE=toolhead_state VALUE=2
+    SAVE_VARIABLE VARIABLE=active_tool VALUE=-1
+    M400
+    TOOL_STATUS
+    RESPOND MSG="⚠️ WARNING! The toolhead status & active tool have been RESET to OPEN & EMPTY!!"
+


### PR DESCRIPTION
Fix camera cal macro names, move cal test inboard, improve load cell cal macro, add manual tool remove & toolhead state resets.

- Camera calibration names with numerics in the middle always fail
  <img width="453" height="220" alt="Cal fail" src="https://github.com/user-attachments/assets/13776d7b-bd1f-40d2-86da-d5e20a52ef10" />

- Changing the names to written numbers fixes this.

- Move testing inbound slightly for peace of mind.

- Improve load cell calibration macro

- Add manual tool remove & set state macro

- Add manual toolhead reset state macro

Feel free to edit or discard what you wish.