### PR TITLE
Update TOOL_STATUS macro not to display on KlipperScreen & update sv …

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -81,32 +81,32 @@ gcode:
     {% endfor %}
     SET_GCODE_VARIABLE MACRO=TOOL_POSITIONS VARIABLE=tools VALUE='{ns.json}]'
 
-    {% set sv = printer.save_variables.variables %}
+    {% set svv = printer.save_variables.variables %}
     # Restore saved latch state so INDX displays the correct Open/Locked label after a
     # firmware restart. The INDX latch is mechanically self-retaining, so the saved value
     # accurately reflects the physical position across restarts.
     # Defaults to 0 (Locked) on first boot before any toolchange has been recorded.
-    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE={sv.toolhead_state|default(0)|int}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=toolhead_state VALUE={svv.toolhead_state|default(0)|int}
 
-    MODE_{sv.tc_mode|default("NORMAL")|upper}
+    MODE_{svv.tc_mode|default("NORMAL")|upper}
     TOOL_STATUS
 
 [gcode_macro TOOL_STATUS]
 gcode:
-    {% set sv = printer.save_variables.variables %}
+    {% set svv = printer.save_variables.variables %}
     {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set st = printer["gcode_macro _TOOLCHANGE_VARS"].toolhead_state|int %}
     {% set mode = printer["gcode_macro _TOOLCHANGE_VARS"].mode|upper %}
     {% set state_label = "🔒 LOCKED" if st == 0 else "🔓 OPEN" %}
-    RESPOND MSG="----------------------------------------"
-    RESPOND MSG="  ⚙️ SPEED MODE:  {mode}"
-    RESPOND MSG="  🔐 LOCK STATE:  {state_label}"
-    RESPOND MSG="  🔧 TOOLS:       {tp.tools|length} configured"
-    RESPOND MSG="  📦 ACTIVE TOOL: {('T' ~ sv.active_tool if sv.active_tool|default(-1)|int >= 0 else 'NONE')}"
-    RESPOND MSG="  🔄 TC COUNT:    {sv.toolchange_count|default(0)|int}"
-    RESPOND MSG="----------------------------------------"
-    RESPOND MSG="  🛠️ INDX STATUS"
-    RESPOND MSG="----------------------------------------"
+    RESPOND TYPE=COMMAND MSG="----------------------------------------"
+    RESPOND TYPE=COMMAND MSG="  ⚙️ SPEED MODE:  {mode}"
+    RESPOND TYPE=COMMAND MSG=="  🔐 LOCK STATE:  {state_label}"
+    RESPOND TYPE=COMMAND MSG="  🔧 TOOLS:       {tp.tools|length} configured"
+    RESPOND TYPE=COMMAND MSG="  📦 ACTIVE TOOL: {('T' ~ svv.active_tool if svv.active_tool|default(-1)|int >= 0 else 'NONE')}"
+    RESPOND TYPE=COMMAND MSG="  🔄 TC COUNT:    {svv.toolchange_count|default(0)|int}"
+    RESPOND TYPE=COMMAND MSG="----------------------------------------"
+    RESPOND TYPE=COMMAND MSG="  🛠️ INDX STATUS"
+    RESPOND TYPE=COMMAND MSG="----------------------------------------"
 
 [gcode_macro INDX]
 gcode: TOOL_STATUS
@@ -128,7 +128,7 @@ gcode:
         {% endif %}
     {% endfor %}
     {% if ns.found %}
-    SET_TMC_CURRENT STEPPER=extruder CURRENT={ns.current}
+        SET_TMC_CURRENT STEPPER=extruder CURRENT={ns.current}
     {% endif %}
 
 

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -100,7 +100,7 @@ gcode:
     {% set state_label = "🔒 LOCKED" if st == 0 else "🔓 OPEN" %}
     RESPOND TYPE=COMMAND MSG="----------------------------------------"
     RESPOND TYPE=COMMAND MSG="  ⚙️ SPEED MODE:  {mode}"
-    RESPOND TYPE=COMMAND MSG=="  🔐 LOCK STATE:  {state_label}"
+    RESPOND TYPE=COMMAND MSG="  🔐 LOCK STATE:  {state_label}"
     RESPOND TYPE=COMMAND MSG="  🔧 TOOLS:       {tp.tools|length} configured"
     RESPOND TYPE=COMMAND MSG="  📦 ACTIVE TOOL: {('T' ~ svv.active_tool if svv.active_tool|default(-1)|int >= 0 else 'NONE')}"
     RESPOND TYPE=COMMAND MSG="  🔄 TC COUNT:    {svv.toolchange_count|default(0)|int}"


### PR DESCRIPTION
Just a bit of housekeeping to make things consistent really. 

Also the command msg change stops the TOOL_STATUS responses being sent to KlipperScreen were as there 9 in a row only the last line is displayed in a green floating window that the user has to either dismiss with a press, or to wait for it to timeout & disappear.

...So all you see at every call of TOOL_STATUS on Klipperscreen is a line of dashes, which is less than ideal tbh, the change displays responses in the console only so makes for a cleaner user experience.

Little nesting thing there as a bonus too...

Please feel free to discard or edit what you wish.