### PR TITLE
_LINEAR_EXIT restore_z to z0 Fix

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -220,7 +220,7 @@ gcode:
 gcode:
     {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
-    {% set restore_z = params.RESTORE_Z|default("")|string %}
+    {% set restore_z = params.RESTORE_Z|default(0)|float %}
 
     {% set clearance_y = tp.clearance_y %}
 
@@ -236,7 +236,7 @@ gcode:
     #    nozzle across the part.
     G90
     _TC_G0 Y={"%.3f"|format(clearance_y)}
-    {% if restore_z != "" %}
+    {% if restore_z > 0 %}
         M400
         _TC_G0 Z={restore_z}
     {% endif %}


### PR DESCRIPTION
If you press T(n) from an un-homed state with a homing override macro that uses `SET_KINEMATIC_POSITION Z=0` in any way to lift the toolhead before G28 homing, line [352](https://github.com/BondtechAB/INDX/blob/483bbe1194605140c9cbb7cd1993684d336342dd/macros/indx-tc-macros.cfg#L352) of the current index-tc-macros.cfg can potentially set the `restore_z` position to 0.000 when the `CHANGE_TOOL` macro evaluates. See photo.

add `M118 restore_z saw {restore_z}mm` after line 352 to test.

<img width="554" height="284" alt="Restore to Z0" src="https://github.com/user-attachments/assets/db8905a5-06c2-417b-b19e-2d064ee39ff3" />


<br>
<br>

This will then proceed to lower the nozzle to the bed (Z0) after the `_LINEAR_EXIT` macro completes. As the current line [239](https://github.com/BondtechAB/INDX/blob/483bbe1194605140c9cbb7cd1993684d336342dd/macros/indx-tc-macros.cfg#L239) sees 0.00 as not ""  so passes that command of `G0 Z0.000` to the `_TC_G0` macro for execution - but can't tell if it's potentially destructive or not.

This way if `restore_z` is passed as 0.000 it is simply not actioned as this outcome is obviously undesirable.