### PR TITLE
feat: add custom homing override for safe axis homing

### DIFF
--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -1,0 +1,105 @@
+[homing_override]
+axes: xyz
+gcode:
+    {% set home_all = not ('X' in params or 'Y' in params or 'Z' in params) %}
+    {% set home_x = home_all or 'X' in params %}
+    {% set home_z = home_all or 'Z' in params %}
+    {% set home_y = home_all or 'Y' in params %}
+    
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    
+    # Set homing_busy to block recursive CHANGE_TOOL calls or other interruptions
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=1
+
+    # Capture the TRUE homed state before we fake anything
+    {% set y_is_homed = 'y' in printer.toolhead.homed_axes %}
+    {% set z_is_homed = 'z' in printer.toolhead.homed_axes %}
+
+    # Before any movement, we need a safe Z hop, to avoid bed scratch.
+    # Fake Z position if unhomed to satisfy Klipper's safety checks
+    {% set safe_z = tp.probe_safe_z_hop|float %}
+    {% if safe_z > 0 %}
+        {% if not z_is_homed %}
+            SET_KINEMATIC_POSITION Z=0
+        {% endif %}
+        G91
+        G0 Z{safe_z} F900
+        G90
+        {% if not z_is_homed %}
+            SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z
+        {% endif %}
+    {% endif %}
+
+    # If we are at real Y < variable_clearance_y,
+    # we already crashed to the tools due to Z hop.
+    # But if we move Y before the Z hop and we were at real Z 0, we scratch the bed.
+    # So the tradeoff is in favor of knocking the tools off, which is less bad than scratching the bed.
+    # If it's the other way around on your printer,
+    # or you value the tools more than the bed,
+    # you can change the order of these two blocks.
+    # However doing Z hop first is only going to damage 1 tool at max,
+    # and it is the least likely as the stock tooldocks have Z movement tolerance for the tool by design.
+
+    # After a Z hop, we need to move to a safe Y position, to avoid tool collisions.
+    # Since Y is not homed yet, we MUST use relative movement (G91).
+    # We move by the distance of clearance_y in the opposite direction of the dock.
+    {% set safe_y_dist = tp.clearance_y|float %}
+    {% if not y_is_homed %}
+        _HOME_Y
+    {% endif %}
+
+    # Now that we sorted the clearances, the rest is easy peasy.
+    {% if home_x %}
+        _HOME_X
+    {% endif %}
+
+    {% if home_z %}
+        _HOME_Z
+    {% endif %}
+
+    # Reset homing_busy now that the process is complete
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+
+[gcode_macro _HOME_Y]
+description: Helper to home Y axis with tool clearance
+gcode:
+    G28 Y
+    RESPOND MSG="Y axis homed"
+
+[gcode_macro _HOME_X]
+description: Helper to home X axis
+gcode:
+    # Bondtech requires Y to be homed before X
+    {% if "y" not in printer.toolhead.homed_axes %}
+        _HOME_Y
+    {% endif %}
+    G28 X
+
+[gcode_macro _HOME_Z]
+description: Helper to home Z axis with tool verification. Home with T0 becase CHANGE_TOOL is responsible for tool offsets and Z offsets are tool-specific.
+gcode:
+    # We need a tool to home properly with Load Cell.
+    {% set active_tool = printer.save_variables.variables.active_tool|default(-1)|int %}
+    {% if active_tool == -1 %}
+        {action_raise_error("Homing failed: Active tool is unknown (-1). Another klipper failure or powerdown? Check the actual tool and update save_variables.active_tool by hand.")}
+    {% endif %}
+    
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set px = tp.probe_x|float %}
+    {% set py = tp.probe_y|float %}
+
+    {% if active_tool != 0 %}
+        CHANGE_TOOL TOOL=0
+    {% endif %}
+
+    {% if "xy" in printer.toolhead.homed_axes %}
+        G0 X{"%.3f"|format(px)} Y{"%.3f"|format(py)} F3000
+    {% endif %}
+    G28 Z
+    
+    {% set safe_z = tp.probe_safe_z_hop|float %}
+    {% if safe_z > 0 %}
+        G90
+        G0 Z{safe_z} F900
+    {% endif %}
+

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -44,7 +44,7 @@ gcode:
     # Since Y is not homed yet, we MUST use relative movement (G91).
     # We move by the distance of clearance_y in the opposite direction of the dock.
     {% set safe_y_dist = tp.clearance_y|float %}
-    {% if not y_is_homed %}
+    {% if home_y %}
         _HOME_Y
     {% endif %}
 
@@ -102,4 +102,3 @@ gcode:
         G90
         G0 Z{safe_z} F900
     {% endif %}
-

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -56,6 +56,7 @@ variable_probe_x:          -1.0   # set to bed centre X, or -1 to auto-detect
 variable_probe_y:          -1.0   # set to bed centre Y, or -1 to auto-detect
 variable_probe_fuzz:         2.0
 variable_probe_z_clearance: 10.0
+variable_probe_safe_z_hop: 3.0
 
 # ── Dock approach direction ──────────────────────────────────────────────────
 #  dock_dir = Y sign into the dock: -1 front (min Y), +1 rear (max Y).


### PR DESCRIPTION
It is the simplest homing macro I could imagine.
It homes Y if not already homed to clear the docs, but before that it does a safe_z_hop.
It uses the new probe_safe_z_hop variable.

It then homes the rest.
Explanation of trade-offs included in comments.

It double check Y is homed when homing X just in case.
It also does a T0 when homing Z to make sure there is a tool in for the load-cell.

This hopefully makes this macro as a good default for further development.