### PR TITLE
Tc exit options

### DIFF
--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -234,7 +234,7 @@ gcode:
                     {% if tp.park_on_ooze_pad %}    
                         G0 X{tp.pad_x|float} 
 						M400
-						Y{tp.pad_y|float} F{params.F|default(final_f)|int}
+						G0 Y{tp.pad_y|float} F{params.F|default(final_f)|int}
 
 					# On exit_pickup when printing the toolhead moves back to exact loaction where the tool change was issued.
         			# When used with "Tool change on wipe tower" this makes sure the nozzle waits & heats on the tower to catch any oozing as there are no guards yet.

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -231,16 +231,10 @@ gcode:
             {% if v.exit_pickup %}
                 {% if printer.print_stats.state in ["printing", "paused"] %}
                     # On exit_pickup when printing the toolhead moves to an ooze pad or filament scraper loaction to heat the tool.
-                    {% if tp.park_on_ooze_pad %}
-                        {% if tp.dock_dir == -1 and tp.pad_y|float < tp.clearance_y|float %}
-                            RESPOND TYPE=error MSG="⚠️ TOOL CHANGE park_on_ooze_pad pad_y is set less than clearance_y please correct this to activate this feature!"
-                            
-                        {% elif tp.dock_dir == 1 and tp.pad_y|float > tp.clearance_y|float %}
-                            RESPOND TYPE=error MSG="⚠️ TOOL CHANGE park_on_ooze_pad pad_y is set greater than clearance_y please correct this to activate this feature!"
-                            
-                        {% else %}
-                        	G0 X{tp.pad_x|float} Y{tp.pad_y|float} F{params.F|default(final_f)|int}
-                        {% endif %}
+                    {% if tp.park_on_ooze_pad %}    
+                        G0 X{tp.pad_x|float} 
+						M400
+						Y{tp.pad_y|float} F{params.F|default(final_f)|int}
 
 					# On exit_pickup when printing the toolhead moves back to exact loaction where the tool change was issued.
         			# When used with "Tool change on wipe tower" this makes sure the nozzle waits & heats on the tower to catch any oozing as there are no guards yet.
@@ -294,25 +288,6 @@ gcode:
     	G0 X{v.restore_x|float} Y{v.restore_y|float} F{params.F|default(final_f)|int}
         M400
         G0 Z{params.Z|float} F{params.F|default(final_f)|int}
-	{% endif %}
-
-[gcode_macro _TC_SCRUB]
-gcode:
-    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
-	{% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
-    {% set final_f = (printer.configfile.settings.printer.max_velocity * 60 * v.speed_mult) %}
-
-	{% if tp.dock_dir == -1 and (tp.tcs_start_y|float < tp.clearance_y|float or tp.tcs_fin_y|float < tp.clearance_y|float) %}
-        RESPOND TYPE=error MSG="⚠️ TOOL CHANGE tc_scrub tcs_start_y or tcs_fin_y is set less than clearance_y please correct this to activate this feature!"
-                            
-    {% elif tp.dock_dir == 1 and (tp.tcs_start_y|float < tp.clearance_y|float or tp.tcs_fin_y|float > tp.clearance_y|float) %}
-        RESPOND TYPE=error MSG="⚠️ TOOL CHANGE tc_scrub tcs_start_y or tcs_fin_y is set greater than clearance_y please correct this to activate this feature!"
-        
-    {% else %}
-    	{% for passes in range(1, (tp.pass_count + 1)) %}
-        	G0 X{tp.tcs_start_x|float} Y{tp.tcs_start_y|float} F{params.F|default(final_f)|int}
-        	G0 X{tp.tcs_fin_x|float} Y{tp.tcs_fin_y|float} F{params.F|default(final_f)|int}
-    	{% endfor %}
 	{% endif %}
 
 [gcode_macro _LINEAR_EXIT]
@@ -602,10 +577,6 @@ gcode:
     # calibration pickups skip this entirely.
     {% if params.TARGET|default(0)|float > 0 %}
         M109 S{params.TARGET|default(0)|float}
-    {% endif %}
-
-    {% if printer.print_stats.state in ["printing", "paused"] and tp.tc_scrub == True and tp.restore_pos == False %}
-        _TC_SCRUB
     {% endif %}
 
     # Record last — save active_tool and increment counter after physical pickup completes

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -61,6 +61,10 @@ variable_accel_mult: 0.7
 variable_speed_mult: 0.7
 variable_toolhead_state: 0 # 0=Locked, 2=Open
 variable_rotation_dist_overridden: 0
+variable_exit_pickup: False
+variable_valid_restore: True
+variable_restore_x: 50
+variable_restore_y: 50
 gcode:
 
 [delayed_gcode INIT_STATE]
@@ -213,14 +217,109 @@ gcode: _SET_MODE M=sport A=1.0 S=1.0 C=1
 [gcode_macro _TC_G0]
 gcode:
     {% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set final_f = (printer.configfile.settings.printer.max_velocity * 60 * v.speed_mult) %}
-    G0 {% if 'X' in params %}X{params.X} {% endif %}{% if 'Y' in params %}Y{params.Y} {% endif %}{% if 'Z' in params %}Z{params.Z} {% endif %}F{params.F|default(final_f)|int}
+
+    {% if (not tp.park_on_ooze_pad and not tp.restore_pos) or not v.exit_pickup %}
+    	G0 {% if 'X' in params %}X{params.X} {% endif %}{% if 'Y' in params %}Y{params.Y} {% endif %}{% if 'Z' in params %}Z{params.Z} {% endif %}F{params.F|default(final_f)|int}
+    
+    {% else %}
+        G0 {% if 'X' in params %}X{params.X} {% endif %}{% if 'Y' in params %}Y{params.Y} {% endif %} F{params.F|default(final_f)|int}
+        M400
+      
+        {% if 'Z' in params %}
+            {% if v.exit_pickup %}
+                {% if printer.print_stats.state in ["printing", "paused"] %}
+                    # On exit_pickup when printing the toolhead moves to an ooze pad or filament scraper loaction to heat the tool.
+                    {% if tp.park_on_ooze_pad %}
+                        {% if tp.dock_dir == -1 and tp.pad_y|float < tp.clearance_y|float %}
+                            RESPOND TYPE=error MSG="⚠️ TOOL CHANGE park_on_ooze_pad pad_y is set less than clearance_y please correct this to activate this feature!"
+                            
+                        {% elif tp.dock_dir == 1 and tp.pad_y|float > tp.clearance_y|float %}
+                            RESPOND TYPE=error MSG="⚠️ TOOL CHANGE park_on_ooze_pad pad_y is set greater than clearance_y please correct this to activate this feature!"
+                            
+                        {% else %}
+                        	G0 X{tp.pad_x|float} Y{tp.pad_y|float} F{params.F|default(final_f)|int}
+                        {% endif %}
+
+					# On exit_pickup when printing the toolhead moves back to exact loaction where the tool change was issued.
+        			# When used with "Tool change on wipe tower" this makes sure the nozzle waits & heats on the tower to catch any oozing as there are no guards yet.
+                    {% elif tp.restore_pos %}
+            			SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=valid_restore VALUE=True
+                      	_TC_XY_RESTORE_CHECK
+                        M400
+                        _TC_XYZ_RESTORE Z={params.Z}
+                    {% endif %}
+                    
+                    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=exit_pickup VALUE=False
+
+                {% else %}
+                    G0 Z{params.Z} F{params.F|default(final_f)|int}
+                    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=exit_pickup VALUE=False 
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
+[gcode_macro _TC_XY_RESTORE_CHECK]
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+
+	{% for i in range(tp.tools|length) %}
+    	{% set p_x = "t" ~ i ~ "_x"|string %}
+        {% set p_y = tp.clearance_y|float %}
+
+        {% if tp.dock_dir == -1 %}
+    		{% if (v.restore_x == tp[p_x] and v.restore_y|float == p_y) or (i == act and v.restore_y|float < p_y) %}
+      			RESPOND TYPE=COMMAND MSG="Restore coordinates create a non-valid exit point. Skipping restore...."
+           		SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=valid_restore VALUE=False 
+    		{% endif %}   
+    	
+        {% else %}
+        	{% if (v.restore_x == tp[p_x] and v.restore_y|float == p_y) or (i == act and v.restore_y|float > p_y) %}
+				RESPOND TYPE=COMMAND MSG="Restore coordinates create a non-valid exit point. Skipping restore...."
+            	SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=valid_restore VALUE=False 
+    		{% endif %}
+    	{% endif %}
+  	{% endfor %}
+
+[gcode_macro _TC_XYZ_RESTORE]
+gcode:
+    {% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
+    {% set final_f = (printer.configfile.settings.printer.max_velocity * 60 * v.speed_mult) %}
+
+    {% if v.valid_restore %}
+    	G0 X{v.restore_x|float} Y{v.restore_y|float} F{params.F|default(final_f)|int}
+        M400
+        G0 Z{params.Z|float} F{params.F|default(final_f)|int}
+	{% endif %}
+
+[gcode_macro _TC_SCRUB]
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+	{% set v = printer["gcode_macro _TOOLCHANGE_VARS"] %}
+    {% set final_f = (printer.configfile.settings.printer.max_velocity * 60 * v.speed_mult) %}
+
+	{% if tp.dock_dir == -1 and (tp.tcs_start_y|float < tp.clearance_y|float or tp.tcs_fin_y|float < tp.clearance_y|float) %}
+        RESPOND TYPE=error MSG="⚠️ TOOL CHANGE tc_scrub tcs_start_y or tcs_fin_y is set less than clearance_y please correct this to activate this feature!"
+                            
+    {% elif tp.dock_dir == 1 and (tp.tcs_start_y|float < tp.clearance_y|float or tp.tcs_fin_y|float > tp.clearance_y|float) %}
+        RESPOND TYPE=error MSG="⚠️ TOOL CHANGE tc_scrub tcs_start_y or tcs_fin_y is set greater than clearance_y please correct this to activate this feature!"
+        
+    {% else %}
+    	{% for passes in range(1, (tp.pass_count + 1)) %}
+        	G0 X{tp.tcs_start_x|float} Y{tp.tcs_start_y|float} F{params.F|default(final_f)|int}
+        	G0 X{tp.tcs_fin_x|float} Y{tp.tcs_fin_y|float} F{params.F|default(final_f)|int}
+    	{% endfor %}
+	{% endif %}
 
 [gcode_macro _LINEAR_EXIT]
 gcode:
     {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set c = printer["gcode_macro _INDX_CONSTANTS"] %}
-    {% set restore_z = params.RESTORE_Z|default("")|string %}
+    {% set restore_z = params.RESTORE_Z|default(0)|float %}
 
     {% set clearance_y = tp.clearance_y %}
 
@@ -236,7 +335,8 @@ gcode:
     #    nozzle across the part.
     G90
     _TC_G0 Y={"%.3f"|format(clearance_y)}
-    {% if restore_z != "" %}
+    {% if restore_z > 0 %}
+        SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=exit_pickup VALUE=True
         M400
         _TC_G0 Z={restore_z}
     {% endif %}
@@ -501,6 +601,10 @@ gcode:
     # calibration pickups skip this entirely.
     {% if params.TARGET|default(0)|float > 0 %}
         M109 S{params.TARGET|default(0)|float}
+    {% endif %}
+
+    {% if printer.print_stats.state in ["printing", "paused"] and tp.tc_scrub == True and tp.restore_pos == False %}
+        _TC_SCRUB
     {% endif %}
 
     # Record last — save active_tool and increment counter after physical pickup completes

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -450,6 +450,7 @@ gcode:
             #    drags the nozzle across the print at both ends of the change.
             {% set zhop = tp.z_hop|float %}
             {% set restore_z = "%.3f"|format(printer.gcode_move.gcode_position.z) %}
+			_RESTORE_GRABBER
 
             # 6. Physical tool swap
             {% if act != -1 %}
@@ -613,6 +614,11 @@ gcode:
 #####################################################################
 #  6. HELPER MACROS
 #####################################################################
+
+[gcode_macro _RESTORE_GRABBER]
+gcode:
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=restore_x VALUE={"%.3f"|format(printer.gcode_move.gcode_position.x)} 
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=restore_y VALUE={"%.3f"|format(printer.gcode_move.gcode_position.y)} 
 
 [gcode_macro _RECORD_TOOLCHANGE]
 description: Inner — saves active_tool and increments the toolchange counter after every successful pickup

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -95,6 +95,37 @@ variable_t2_dock_y: -26
 variable_t3_x:     102.0
 variable_t3_dock_y: -26
 
+# ── Tool change behaviour when printing ───────────────────────────────────────
+# park_on_ooze_pad = if you have an ooze pad or filament scraper on your X/Y axes
+#					         The nozzle will go to this location after a tool change to heat up.
+
+# pad_x            = Location on X axis.
+# pad_Y 		       = Location on Y axis.
+
+# restore_pos      = goes to the last location before the tool change to heat up
+#                    best used with your slicer's "Tool Change on Wipe Tower" setting.
+
+# NOTE: park_on_ooze_pad overrides the restore_pos setting! Also if both are set False
+#       the standard Bondtech tool change process is carried out.
+
+# NOTE: Don't set pad_x or pad_y where they'll hit the edge of the printer's travel
+#       on either axis as you could end up with layer shifts &/or possible machine damage.
+
+# tc_scrub         = Choose to use a gantry mounted nozzle cleaner if you have one.
+# pass_count       = Choose how many times the nozzle moves from tcs_start to tcs_fin locations.
+
+variable_park_on_ooze_pad: False
+variable_pad_x: 10.00
+variable_pad_y: 26.00
+variable_restore_pos: True
+
+variable_tc_scrub: False
+variable_pass_count: 2
+variable_tcs_start_x: 10
+variable_tcs_start_y: 26
+variable_tcs_fin_x: 10 
+variable_tcs_fin_y: 46 
+
 # ── Assembled at startup from the variables above — do not edit ──────────────
 variable_tools: []
 

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -111,20 +111,10 @@ variable_t3_dock_y: -26
 # NOTE: Don't set pad_x or pad_y where they'll hit the edge of the printer's travel
 #       on either axis as you could end up with layer shifts &/or possible machine damage.
 
-# tc_scrub         = Choose to use a gantry mounted nozzle cleaner if you have one.
-# pass_count       = Choose how many times the nozzle moves from tcs_start to tcs_fin locations.
-
 variable_park_on_ooze_pad: False
 variable_pad_x: 10.00
 variable_pad_y: 26.00
 variable_restore_pos: True
-
-variable_tc_scrub: False
-variable_pass_count: 2
-variable_tcs_start_x: 10
-variable_tcs_start_y: 26
-variable_tcs_fin_x: 10 
-variable_tcs_fin_y: 46 
 
 # ── Assembled at startup from the variables above — do not edit ──────────────
 variable_tools: []


### PR DESCRIPTION
Add TC exit options for users.

- Use default behaviour, by turning all new systems off, or..... - EDIT restore_pos is default on, current default operation is used when restore_pos & park on ooze pad are off.
- Park on a gantry mounted purge/ooze pad after pickup to fully heat to catch any oozing
- Choose pad location to park
- Clean nozzle on a gantry mounted nozzle cleaner - REMOVED
- Choose start & finish scrubbing locations & pass count - REMOVED
- Or choose to restore the last XYZ position before the tool change was initiated. This works best if you select "change on wipe tower" in the slicer.

restore_pos operation....
This variable enables an active restore system that changes the default TC return behaviour. So instead of picking up a tool &  immediately restoring the TC Z height at the clearance_y threshold & heating this variable enables the toolhead to pass the clearance-y location & returns it to the location where the TC was called. Preferably the purge/wipe tower (use slicer setting) once at the restored XY coordinates the toolhead then lowers back to the restored Z height & waits to fully heat.
This makes sure the toolhead passes cleanly above the top of any print on the bed & heats the nozzle into the purge tower catching any oozing filament as it dos so.

- The system runs checks that will bypass functions with warnings if set variables encroach on docked tools clearance Y values & if restore_pos locations are in front of other tool's dock & match their exit positions.

- The ooze_pad park & tc_scrub clean nozzle systems can be combined, however the restore pos & nozzle clean can not. - tc_scrub REMOVED

- The ooze_pad variable overrides the restore_pos setting.