### PR TITLE
Add per-tool nozzle temperature control to CAL_Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,9 +1370,22 @@ Regardless of which XY method you use, Z offsets are set automatically using the
 CAL_Z
 ```
 
+By default, calibration is performed cold, preserving the existing behaviour. To
+measure offsets with every nozzle at the same temperature, pass a nozzle target and
+an optional soak time:
+
+```gcode
+CAL_Z NOZZLE_TEMP=150 SOAK=10
+```
+
+Each tool is heated only after pickup, held at the target for the requested soak,
+then measured. The heater is switched off before that tool is parked. The bed heater
+is not controlled by `CAL_Z`.
+
 Prerequisites:
 - Printer homed (homes automatically if not)
 - **No filament available to the extruder gears in any tool** — if filament is loaded, latch engage moves during pickup can spike load-cell readings and cause calibration to fail.
+- When using `NOZZLE_TEMP`, make sure the nozzle tips are clean. Any softened filament on a nozzle can affect the load-cell measurement.
 
 Per tool, the macro:
 1. Picks up the tool

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -157,6 +157,7 @@ gcode:
 #
 #  Usage:
 #    CAL_Z
+#    CAL_Z NOZZLE_TEMP=150 SOAK=10
 #
 #  Prerequisites:
 #    - Printer homed (auto-homes if not)
@@ -177,6 +178,8 @@ gcode:
 #                      circle (non-center positions only)
 #    probe_speed     — normal probe speed (mm/s); halved after 2 fuzzes
 #    sample_count    — final clean probes per tool for the median
+#    nozzle_temp     — runtime nozzle target; 0 keeps the current cold behaviour
+#    nozzle_soak     — seconds to soak each attached tool at nozzle_temp
 #
 #####################################################################
 
@@ -188,6 +191,8 @@ variable_probe_speed:        3.0   # normal probe speed mm/s (halved after 2 fuz
 variable_probe_retract:      1.0   # Z retract between convergence/sample probes (mm, relative)
 variable_toolchange_z:      20.0   # minimum Z before each CHANGE_TOOL (nozzle clearance, mm)
 variable_sample_count:         5   # final clean probes per tool — median saved as result
+variable_nozzle_temp:         0.0   # runtime nozzle target; 0 disables heating
+variable_nozzle_soak:         0.0   # runtime soak after reaching nozzle_temp (seconds)
 gcode:
     RESPOND MSG="CAL_Z: Make sure no filament is available to the extruder gears in any tool."
     {% set tp  = printer["gcode_macro TOOL_POSITIONS"] %}
@@ -198,6 +203,12 @@ gcode:
     {% set spd = cfg.probe_speed|float %}
     {% set loc = cfg.probe_location %}
     {% set ins = cfg.edge_inset|float %}
+    {% set nozzle_temp = params.NOZZLE_TEMP|default(0)|float %}
+    {% set nozzle_soak = params.SOAK|default(0)|float %}
+
+    {% if nozzle_temp < 0 or nozzle_soak < 0 %}
+        {action_raise_error("CAL_Z requires NOZZLE_TEMP>=0 and SOAK>=0")}
+    {% endif %}
 
     {% if "xyz" not in printer.toolhead.homed_axes %}
         G28
@@ -205,6 +216,8 @@ gcode:
 
     SAVE_VARIABLE VARIABLE=v2z_total_tools  VALUE={n}
     SAVE_VARIABLE VARIABLE=v2z_current_tool VALUE=0
+    SET_GCODE_VARIABLE MACRO=CAL_Z VARIABLE=nozzle_temp VALUE={nozzle_temp}
+    SET_GCODE_VARIABLE MACRO=CAL_Z VARIABLE=nozzle_soak VALUE={nozzle_soak}
 
     # Compute clean probe centre from bed dimensions and probe_location
     {% set th  = printer.toolhead %}
@@ -224,6 +237,11 @@ gcode:
     RESPOND MSG="  Clean probe    X={'%.2f'|format(pns.cx)}  Y={'%.2f'|format(pns.cy)}"
     RESPOND MSG="  Convergence    SD < 0.005 mm over 4-sample window  (fuzz after 7)"
     RESPOND MSG="  Final samples  {sc} probes → median"
+    {% if nozzle_temp > 0 %}
+        RESPOND MSG="  Nozzle         {'%.1f'|format(nozzle_temp)}C / soak {'%.0f'|format(nozzle_soak)}s per tool"
+    {% else %}
+        RESPOND MSG="  Nozzle         cold (heater not controlled)"
+    {% endif %}
     RESPOND MSG="  Probe speed    {'%.1f'|format(spd)} mm/s  (→ {'%.1f'|format(spd/2)} after 2 fuzz moves)"
     RESPOND MSG="═══════════════════════════════════════════════"
 
@@ -283,6 +301,13 @@ gcode:
         G0 Z{'%.3f'|format(tc_z)} F3000
         CHANGE_TOOL TOOL={i} SKIP_Z_CORRECTION=1
         _CAL_LATCH_ENGAGE
+        {% if cfg.nozzle_temp|float > 0 %}
+            RESPOND MSG="  T{i} — heating to {'%.1f'|format(cfg.nozzle_temp|float)}C, then soaking {'%.0f'|format(cfg.nozzle_soak|float)}s"
+            M109 S{cfg.nozzle_temp|float}
+            {% if cfg.nozzle_soak|float > 0 %}
+                G4 P{(cfg.nozzle_soak|float * 1000)|int}
+            {% endif %}
+        {% endif %}
         G90
         G0 Z{z_clr} F1500
         G0 X{'%.3f'|format(dns.ix)} Y{'%.3f'|format(dns.iy)} F8000
@@ -518,6 +543,11 @@ gcode:
 
     RESPOND MSG="  T{i}  median of {sc} samples: {'%.4f'|format(median)}"
     SAVE_VARIABLE VARIABLE={'v2z_result_%d' % i} VALUE={'%.6f'|format(median)}
+    {% if cfg.nozzle_temp|float > 0 %}
+        # A parked tool cannot be heated. Switch the heater off before the
+        # next CHANGE_TOOL parks this tool and picks up the next one.
+        M104 S0
+    {% endif %}
     SAVE_VARIABLE VARIABLE=v2z_current_tool VALUE={i + 1}
     UPDATE_DELAYED_GCODE ID=_cz_tool_loop DURATION=0.1
 


### PR DESCRIPTION
## Summary

- add optional NOZZLE_TEMP and SOAK parameters to CAL_Z
- heat each passive tool only after pickup, so every nozzle is measured at the same requested temperature
- switch the heater off after measuring each tool and before it is parked
- preserve the existing cold CAL_Z behaviour when NOZZLE_TEMP is omitted
- document the command and hot-probing precautions

Example:

`gcode
CAL_Z NOZZLE_TEMP=150 SOAK=10
`

The bed heater is intentionally not controlled. CAL_Z measures the tools at the same XY location, while heating the bed adds stabilization time and another source of drift without being necessary to equalize the individual nozzle temperatures.

## Motivation

The passive tools cannot be preheated while parked. Heating once at the beginning of CAL_Z therefore does not put subsequently picked tools into the same thermal state. This change waits for each attached nozzle individually before probing it.

On the test printer, the measured relative Z difference changed by about 0.025 mm between cold and 200 C nozzle measurements, which is significant for first-layer calibration.

## Validation

Tested on a six-tool Bondtech INDX installed on a Voron Trident 350:

- bed unheated
- nozzle target 200 C
- 30 second soak per tool
- two consecutive complete six-tool runs
- every pickup and park completed successfully
- heater was switched off before each park and all heaters were off at completion

The documented 150 C example follows the temperature previously suggested for CAL_Z in the discussion on #36.