### PR TITLE
feat: macros - add load-cell gated homing override

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,13 +976,13 @@ With a dock mounted on your printer, the default homing sequence can cause crash
 
 The INDX macro package includes a ready-to-use `[homing_override]` in `homing.cfg` that handles all of this. Its sequence, in full:
 
-1. If Z is already known: raise to `probe_z_clearance` (set in `indx.cfg`). If Z is unknown: a relative hop of that height (kinematic Z=0, then `CLEAR_HOMED`).
+1. Raise to `probe_z_clearance` (set in `indx.cfg`). If Z is unknown, hop that height then un-home Z so the later probe is a real home.
 2. Home Y. `G28 X` with Y unknown homes Y first.
-3. Home X. If Y was already known and the head is still on the dock side (`dock_dir` in `indx.cfg`), move to `clearance_y` first so X does not sweep the dock. Just-homed Y is already at the endstop, so X homes immediately.
-4. Before Z: read the load cell. Soft-state (`active_tool`) is not enough - a stale empty flag with a tool still locked would send `CHANGE_TOOL T0` into that tool. Missing or uncalibrated load cell is an error. Seat is `abs(force_g + tare_force) >= home_min_force_g` (set in `indx.cfg`, default 800). If the cell sees a tool and `active_tool` is unknown, that is an error. If the cell is empty and Z has been homed before, pick T0 (including when soft-state already says T0) and read again. If the cell is empty and Z has never been homed, stop and seat a tool by hand - the dock is not safe at a guessed height. If a tool is already locked and the cell agrees, Z homes with that tool (its XY/Z offsets are re-applied before the probe).
+3. Home X. If Y was already homed and the head is still on the dock side (`dock_dir` in `indx.cfg`), move to `clearance_y` first so X does not sweep the dock.
+4. Before Z, read the load cell. The saved tool number is not enough: it can say empty while a tool is still locked, which would crash a T0 pickup. Missing or uncalibrated cell is an error. Tune seat with `home_min_force_g` in `indx.cfg` (default 800). If nothing is seated and Z has never been homed, seat a tool by hand. If Z is already known, pick T0. If a tool is already locked and the cell agrees, home Z with that tool.
 5. Move to the probe XY (`probe_x` / `probe_y`, or bed centre) and home Z.
 
-`CAL_Z` still stores per-tool Z offsets relative to T0. Homing no longer requires T0 when another tool is already locked and the load cell confirms it - toolchanges keep applying `tool_z + global_z`, so nozzle height stays consistent after a non-T0 Z home.
+`CAL_Z` still stores per-tool Z offsets relative to T0. Homing no longer requires T0 when another tool is already locked and the load cell confirms it.
 
 If you use sensorless XY homing, wrap the `G28 Y` / `G28 X` steps in your usual TMC current reduce/restore (merge into the override if you already have one).
 

--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ The INDX firmware plugin provides a set of `.cfg` files you include from `printe
 | `indx.cfg` | User configuration: tool positions and related settings. **The only file you need to edit.** |
 | `indx-tc-macros.cfg` | Tool change logic: `CHANGE_TOOL`, `PARK_TOOL`, boot detection. Do not edit. |
 | `indx-cal.cfg` | Calibration macros: dock position, XY/Z offset calibration. |
+| `homing.cfg` | `[homing_override]`: Y then X, load-cell seat check, then Z. Do not edit. |
 
 Include them from your `printer.cfg`:
 
@@ -882,7 +883,10 @@ Include them from your `printer.cfg`:
 [include indx/indx.cfg]
 [include indx/indx-tc-macros.cfg]
 [include indx/indx-cal.cfg]
+[include indx/homing.cfg]
 ```
+
+Klipper allows only one `[homing_override]`. If your printer already has one (sensorless current, bed raiser, etc.), merge the INDX sequence into yours instead of including `homing.cfg` as-is.
 
 ##### Required Klipper sections
 
@@ -968,26 +972,27 @@ The `indx-cal.cfg` macros wrap this into the calibration commands you actually r
 
 ##### Homing order (important)
 
-With a dock mounted on your printer, the default homing sequence can cause crashes. The Smart Head must move away from the dock before X is homed, and if a tool other than T0 is currently mounted it must be parked before Z is homed.
+With a dock mounted on your printer, the default homing sequence can cause crashes. The Smart Head must move away from the dock before X is homed, and Z homing needs a seated tool (the load cell is the nozzle probe).
 
 The INDX macro package includes a ready-to-use `[homing_override]` in `homing.cfg` that handles all of this. Its sequence, in full:
 
-1. Move Z up slightly to clear the bed before any XY movement (move bed down if using a bed raiser)
-2. Home Y (with reduced TMC current for sensorless homing)
-3. Home X (with reduced TMC current for sensorless homing)
-4. If any tool other than T0 is active: park it in the dock
-5. If T0 is not already picked up: pick up T0
-6. Move to bed centre and home Z
+1. If Z is already known: raise to `probe_z_clearance` (set in `indx.cfg`). If Z is unknown: a relative hop of that height (kinematic Z=0, then `CLEAR_HOMED`).
+2. Home Y. `G28 X` with Y unknown homes Y first.
+3. Home X. If Y was already known and the head is still on the dock side (`dock_dir` in `indx.cfg`), move to `clearance_y` first so X does not sweep the dock. Just-homed Y is already at the endstop, so X homes immediately.
+4. Before Z: read the load cell. Soft-state (`active_tool`) is not enough - a stale empty flag with a tool still locked would send `CHANGE_TOOL T0` into that tool. Missing or uncalibrated load cell is an error. Seat is `abs(force_g + tare_force) >= home_min_force_g` (set in `indx.cfg`, default 800). If the cell sees a tool and `active_tool` is unknown, that is an error. If the cell is empty and Z has been homed before, pick T0 (including when soft-state already says T0) and read again. If the cell is empty and Z has never been homed, stop and seat a tool by hand - the dock is not safe at a guessed height. If a tool is already locked and the cell agrees, Z homes with that tool (its XY/Z offsets are re-applied before the probe).
+5. Move to the probe XY (`probe_x` / `probe_y`, or bed centre) and home Z.
 
-T0 is always the reference tool for Z homing. This ensures Z is always probed with the same tool, keeping Z offsets for all other tools consistent.
+`CAL_Z` still stores per-tool Z offsets relative to T0. Homing no longer requires T0 when another tool is already locked and the load cell confirms it - toolchanges keep applying `tool_z + global_z`, so nozzle height stays consistent after a non-T0 Z home.
+
+If you use sensorless XY homing, wrap the `G28 Y` / `G28 X` steps in your usual TMC current reduce/restore (merge into the override if you already have one).
 
 **Review your `PRINT_START` macro**
 
 If you are migrating from a single-toolhead printer, your existing `PRINT_START` macro almost certainly heats the hotend before printing starts, something like `M104 S{first_layer_temperature}` or `M109 S{first_layer_temperature}`. With INDX, this will cause problems: there is no hotend to heat until a tool has been picked up by the Smart Head.
 
-> ⚠️ Any hotend heating commands in your `PRINT_START` macro must come **after** the first tool pick-up (`T0`). Sending a heat command before a tool is picked up will result in an error, and depending on your macro structure, may cause a crash or leave the printer in a bad state.
+> ⚠️ Any hotend heating commands in your `PRINT_START` macro must come **after** the first tool pick-up. Sending a heat command before a tool is picked up will result in an error, and depending on your macro structure, may cause a crash or leave the printer in a bad state.
 
-Review your `PRINT_START` macro and move all `M104`/`M109` (and any temperature wait commands) to after the first `T0` call. If you are writing a fresh macro, pick up a tool first, then heat.
+Review your `PRINT_START` macro and move all `M104`/`M109` (and any temperature wait commands) to after the first tool pick (`Tn` / `CHANGE_TOOL`). If you are writing a fresh macro, pick up a tool first, then heat.
 
 #### RRF (RepRapFirmware)
 
@@ -1817,7 +1822,7 @@ After rebooting, run `ls /dev/serial/by-id/` to confirm the Link Board is now vi
 
 If the Smart Head slams into the dock or the docked tools when you run `G28`, the most likely cause is that the homing order has not been configured. By default, Klipper homes X before Y; if the Smart Head is near the dock when homing starts, a full-speed X move can send it directly into the dock.
 
-Add a `[homing_override]` section to your `printer.cfg` that homes Y before X. See [Homing order](#homing-order-important) for the recommended config. After any crash, re-home the printer before moving on; the stepper motors may have lost steps, making the position shown in your interface unreliable.
+Include `homing.cfg` (or merge its `[homing_override]` into yours) so Y homes before X. See [Homing order](#homing-order-important). After any crash, re-home the printer before moving on; the stepper motors may have lost steps, making the position shown in your interface unreliable.
 
 ### Extruder feeding filament in the wrong direction
 

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -1,0 +1,264 @@
+#####################################################################
+#  INDX HOMING OVERRIDE
+#####################################################################
+#
+#  Include AFTER the other INDX macros:
+#    [include indx/indx.cfg]
+#    [include indx/indx-tc-macros.cfg]
+#    [include indx/indx-cal.cfg]
+#    [include indx/homing.cfg]
+#
+#  Klipper allows only ONE [homing_override]. If your printer.cfg
+#  already has one (sensorless current, bed raiser, etc.), merge this
+#  sequence into yours - do not include both.
+#
+#  Sequence (full G28):
+#    1. _INDX_SAFE_Z_HOP before any axis home:
+#       Z known: ensure at/above probe_z_clearance; Z unknown: relative
+#       +probe_z_clearance (kinematic Z=0, then CLEAR_HOMED)
+#    2. Home Y if needed (X always requires Y)
+#    3. Before X: if Y already known, G0 to clearance_y when still on
+#       the dock side: (cur_y - clearance_y) * dock_dir > 0.
+#       Just-homed Y: home X immediately (this template still sees
+#       pre-home Y, so it must not G0 from that stale value).
+#    4. Home X
+#    5. If Z requested: remember whether Z was already homed (before
+#       fake-home), load-cell verify, then keep the seated tool or
+#       CHANGE_TOOL T0 if the cell is empty and Z has been homed
+#       before. First Z home with an empty cell is refused - seat by
+#       hand. Verify again after pickup. Re-apply offsets (MOVE=0)
+#       when already seated, travel to probe XY, G28 Z.
+#
+#  Z home does not trust save_variables.active_tool. Soft-state can
+#  say empty while a tool is locked; CHANGE_TOOL T0 would then drive
+#  into it. _INDX_HOME_VERIFY must see a seated tool before any probe,
+#  and before T0 pickup if the cell already reads loaded with
+#  active_tool == -1 (that is an error, not a pickup).
+#  Missing or uncalibrated load cell is an error, not a skip.
+#  homing_busy is set only around CHANGE_TOOL T0, not around G28 Y/X.
+#
+#  G28 Z homes with whatever tool the cell confirms (active_tool >= 0).
+#  Empty cell after a real Z home: CHANGE_TOOL T0 (clears a stale T0
+#  active_tool first so CHANGE_TOOL is not a no-op), then verify again.
+#  CAL_Z offsets stay T0-relative; toolchange still applies tool_z+global_z.
+#  XY must be homed before G28 Z (G28 Z alone does not home XY).
+#
+#  Sensorless XY: add your TMC current reduce/restore around the
+#  G28 Y / G28 X lines if your printer needs it.
+#
+#  Manual check:
+#    - G28 with locked tool (any Tn): Y, X, Z succeed without docking to T0
+#    - G28 Z with XY unhomed: errors
+#    - G28 Z with empty cell and Z previously homed: dock-picks T0, verifies, then probes
+#    - G28 Z with empty cell and Z never homed: errors (seat a tool by hand)
+#    - G28 Z with active_tool T0 but cell empty: clears T0, picks T0, verifies
+#    - G28 Z with tool on the cell and active_tool -1: errors
+#    - G28 Z with no load cell / uncalibrated: errors
+#    - G28 X Y only: no tool pickup, no Z move
+#    - G28 X with Y unknown: homes Y, then homes X
+#    - G28 X with Y known on dock side: clears to clearance_y, then X
+#
+#####################################################################
+
+[homing_override]
+axes: xyz
+gcode:
+    {% set home_all = not ('X' in params or 'Y' in params or 'Z' in params) %}
+    {% set home_x = home_all or 'X' in params %}
+    {% set home_z = home_all or 'Z' in params %}
+    # X requires Y: G28 X with Y unknown homes Y first
+    {% set home_y = home_all or 'Y' in params
+        or (home_x and "y" not in printer.toolhead.homed_axes) %}
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+
+    # 1. Clear Z before any axis home
+    _INDX_SAFE_Z_HOP
+
+    # 2. Home Y first (X-first can sweep into tools)
+    {% if home_y %}
+        G28 Y
+    {% endif %}
+
+    # 3. Before X: if Y was already known, ensure clear of docks.
+    # Just-homed Y: endstop is fine for X - home X immediately.
+    {% if home_x %}
+        {% if not home_y %}
+            {% set cur_y = printer.toolhead.position.y|float %}
+            {% set clear_y = tp.clearance_y|float %}
+            {% if (cur_y - clear_y) * (tp.dock_dir|float) > 0 %}
+                G90
+                G0 Y{"%.3f"|format(clear_y)} F3000
+            {% endif %}
+        {% endif %}
+        G28 X
+    {% endif %}
+
+    # 4. Z needs a seated tool (load cell = nozzle probe)
+    {% if home_z %}
+        _INDX_HOME_Z
+    {% endif %}
+
+[gcode_macro _INDX_SAFE_Z_HOP]
+description: Inner - clear Z to probe_z_clearance before any axis home
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set z_clr = tp.probe_z_clearance|float %}
+    {% if "z" not in printer.toolhead.homed_axes %}
+        SET_KINEMATIC_POSITION Z=0 SET_HOMED=Z
+        G91
+        G0 Z{z_clr} F900
+        G90
+        # Empty SET_HOMED= is required: CLEAR_HOMED=Z alone defaults SET_HOMED=XYZ
+        SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z
+    {% elif printer.toolhead.position.z|float < z_clr %}
+        G90
+        G0 Z{z_clr} F900
+    {% endif %}
+
+[gcode_macro _INDX_HOME_VERIFY]
+description: Inner - settle and read load-cell seat, then call AFTER_SOFT or AFTER_HARD
+variable_last_ok: -1
+variable_last_force_g: 0.0
+variable_settle_ms: 800
+variable_next_hard: 0
+gcode:
+    {% set nxt_hard = 1 if params.NEXT|default("soft") == "hard" else 0 %}
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_VERIFY VARIABLE=next_hard VALUE={nxt_hard}
+    M400
+    G4 P{printer["gcode_macro _INDX_HOME_VERIFY"].settle_ms|int}
+    _INDX_HOME_VERIFY_READ
+
+[gcode_macro _INDX_HOME_VERIFY_READ]
+description: Inner - fail closed if the load cell is missing or uncalibrated; else continue
+gcode:
+    {% set v = printer["gcode_macro _INDX_HOME_VERIFY"] %}
+    {% set min_g = printer["gcode_macro TOOL_POSITIONS"].home_min_force_g|default(800.0)|float %}
+    {% set ns = namespace(ok=0, force=0.0, err="") %}
+
+    {% if 'load_cell_probe' not in printer %}
+        {% set ns.err = "Cannot home Z: [load_cell_probe] is not loaded" %}
+    {% else %}
+        {% set lc = printer.load_cell_probe %}
+        {% set fg = lc.force_g|default(none) %}
+        {% if not lc.is_calibrated|default(false) or fg is none %}
+            {% set ns.err = "Cannot home Z: load cell is not calibrated" %}
+        {% else %}
+            {% set ns.force = fg|float + lc.tare_force|default(0.0)|float %}
+            {% if ns.force|abs >= min_g %}
+                {% set ns.ok = 1 %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_VERIFY VARIABLE=last_ok VALUE={ns.ok}
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_VERIFY VARIABLE=last_force_g VALUE={ns.force}
+    {% if ns.err %}
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"{ns.err}"'
+        _INDX_HOME_Z_FAIL
+    {% elif v.next_hard|int %}
+        _INDX_HOME_Z_AFTER_HARD
+    {% else %}
+        _INDX_HOME_Z_AFTER_SOFT
+    {% endif %}
+
+[gcode_macro _INDX_HOME_Z]
+description: Inner - load-cell verify, then keep seated tool or pick T0, then probe Z
+variable_z_known: 0
+gcode:
+    {% if "xy" not in printer.toolhead.homed_axes %}
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Must home X and Y before Z"'
+        _INDX_HOME_Z_FAIL
+    {% else %}
+        # Record real Z-homed before fake-home. SAFE_Z_HOP already cleared
+        # unknown Z; an empty cell must not dock-pick T0 on that first home.
+        {% set z_known = 1 if "z" in printer.toolhead.homed_axes else 0 %}
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_known VALUE={z_known}
+        # SAFE_Z_HOP leaves Z unhomed so the final G28 Z actually probes.
+        # Mark Z homed at the current height before CHANGE_TOOL / offsets /
+        # probe XY travel. A non-T0 SET_GCODE_OFFSET plus z_tilt or bed mesh
+        # turns G0 X Y into a Z move, which Klipper rejects while Z is unhomed.
+        {% if "z" not in printer.toolhead.homed_axes %}
+            SET_KINEMATIC_POSITION SET_HOMED=Z
+        {% endif %}
+        _INDX_HOME_VERIFY NEXT=soft
+    {% endif %}
+
+[gcode_macro _INDX_HOME_Z_AFTER_SOFT]
+description: Inner - after verify: refuse unknown seat, pick T0 only if the cell is empty
+gcode:
+    {% set last_ok = printer["gcode_macro _INDX_HOME_VERIFY"].last_ok|int %}
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+
+    {% set z_known = printer["gcode_macro _INDX_HOME_Z"].z_known|int %}
+
+    {% if last_ok == 1 and act < 0 %}
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: tool detected but active_tool is unknown (-1). Run CHANGE_TOOL or fix latch state."'
+        _INDX_HOME_Z_FAIL
+    {% elif last_ok != 1 %}
+        {% if not z_known %}
+            SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: no tool seated. Seat and lock a tool by hand, then G28 Z."'
+            _INDX_HOME_Z_FAIL
+        {% else %}
+            # CHANGE_TOOL is a no-op when act already equals TOOL. Stale T0
+            # with an empty cell would otherwise skip pickup.
+            {% if act == 0 %}
+                SAVE_VARIABLE VARIABLE=active_tool VALUE=-1
+            {% endif %}
+            SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=1
+            CHANGE_TOOL TOOL=0
+            SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+            _INDX_HOME_VERIFY NEXT=hard
+        {% endif %}
+    {% else %}
+        {% set svv = printer.save_variables.variables %}
+        {% set tool_x = svv["t" ~ act ~ "_offset_x"]|default(0.0)|float %}
+        {% set tool_y = svv["t" ~ act ~ "_offset_y"]|default(0.0)|float %}
+        {% set tool_z = svv["t" ~ act ~ "_offset_z"]|default(0.0)|float %}
+        {% set global_z = svv.global_z_offset|default(0.0)|float %}
+        SET_GCODE_OFFSET X={"%.3f"|format(tool_x)} Y={"%.3f"|format(tool_y)} Z='{"%.3f"|format(tool_z + global_z)}' MOVE=0
+        _INDX_HOME_Z_PROBE
+    {% endif %}
+
+[gcode_macro _INDX_HOME_Z_AFTER_HARD]
+description: Inner - after T0 pickup: abort if the cell still does not see a tool
+gcode:
+    {% set last_ok = printer["gcode_macro _INDX_HOME_VERIFY"].last_ok|int %}
+    {% if last_ok != 1 %}
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: T0 not seated after pickup"'
+        _INDX_HOME_Z_FAIL
+    {% else %}
+        _INDX_HOME_Z_PROBE
+    {% endif %}
+
+[gcode_macro _INDX_HOME_Z_PROBE]
+description: Inner - move to probe XY and G28 Z
+gcode:
+    {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
+    {% set th = printer.toolhead %}
+    {% set px = tp.probe_x|float %}
+    {% set py = tp.probe_y|float %}
+    {% if px < 0 %}
+        {% set px = (th.axis_minimum.x + th.axis_maximum.x) / 2 %}
+    {% endif %}
+    {% if py < 0 %}
+        {% set py = (th.axis_minimum.y + th.axis_maximum.y) / 2 %}
+    {% endif %}
+
+    G90
+    G0 X{"%.3f"|format(px)} Y{"%.3f"|format(py)} F3000
+    G28 Z
+    {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
+    SAVE_VARIABLE VARIABLE=z_home_tool VALUE={act}
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+
+[gcode_macro _INDX_HOME_Z_FAIL]
+description: Inner - clear homing_busy then raise (raise aborts template eval)
+variable_msg: ""
+gcode:
+    SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+    _INDX_HOME_Z_FAIL_RAISE
+
+[gcode_macro _INDX_HOME_Z_FAIL_RAISE]
+description: Inner - raise after busy is cleared
+gcode:
+    {action_raise_error(printer["gcode_macro _INDX_HOME_Z_FAIL"].msg)}

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -13,50 +13,28 @@
 #  sequence into yours - do not include both.
 #
 #  Sequence (full G28):
-#    1. _INDX_SAFE_Z_HOP before any axis home:
-#       Z known: ensure at/above probe_z_clearance; Z unknown: relative
-#       +probe_z_clearance (kinematic Z=0, then CLEAR_HOMED)
-#    2. Home Y if needed (X always requires Y)
-#    3. Before X: if Y already known, G0 to clearance_y when still on
-#       the dock side: (cur_y - clearance_y) * dock_dir > 0.
-#       Just-homed Y: home X immediately (this template still sees
-#       pre-home Y, so it must not G0 from that stale value).
-#    4. Home X
-#    5. If Z requested: remember whether Z was already homed (before
-#       fake-home), load-cell verify, then keep the seated tool or
-#       CHANGE_TOOL T0 if the cell is empty and Z has been homed
-#       before. First Z home with an empty cell is refused - seat by
-#       hand. Verify again after pickup. Re-apply offsets (MOVE=0)
-#       when already seated, travel to probe XY, G28 Z.
+#    1. Raise to probe_z_clearance. If Z is unknown, hop then un-home Z
+#       so the later probe is a real home.
+#    2. Home Y (X always needs Y first).
+#    3. Home X. If Y was already homed and the head is still on the
+#       dock side, move to clearance_y first.
+#    4. Before Z, the load cell must show a seated tool. The saved
+#       tool number is not trusted. First Z home with no tool: seat
+#       by hand. Later, empty cell: pick T0 and check again. Then
+#       probe at probe_x / probe_y.
 #
-#  Z home does not trust save_variables.active_tool. Soft-state can
-#  say empty while a tool is locked; CHANGE_TOOL T0 would then drive
-#  into it. _INDX_HOME_VERIFY must see a seated tool before any probe,
-#  and before T0 pickup if the cell already reads loaded with
-#  active_tool == -1 (that is an error, not a pickup).
-#  Missing or uncalibrated load cell is an error, not a skip.
-#  homing_busy is set only around CHANGE_TOOL T0, not around G28 Y/X.
+#  G28 Z homes with whatever tool is seated. CAL_Z offsets stay
+#  relative to T0. Home XY before G28 Z.
 #
-#  G28 Z homes with whatever tool the cell confirms (active_tool >= 0).
-#  Empty cell after a real Z home: CHANGE_TOOL T0 (clears a stale T0
-#  active_tool first so CHANGE_TOOL is not a no-op), then verify again.
-#  CAL_Z offsets stay T0-relative; toolchange still applies tool_z+global_z.
-#  XY must be homed before G28 Z (G28 Z alone does not home XY).
+#  Sensorless XY: wrap G28 Y / G28 X with your TMC current change.
 #
-#  Sensorless XY: add your TMC current reduce/restore around the
-#  G28 Y / G28 X lines if your printer needs it.
-#
-#  Manual check:
-#    - G28 with locked tool (any Tn): Y, X, Z succeed without docking to T0
-#    - G28 Z with XY unhomed: errors
-#    - G28 Z with empty cell and Z previously homed: dock-picks T0, verifies, then probes
-#    - G28 Z with empty cell and Z never homed: errors (seat a tool by hand)
-#    - G28 Z with active_tool T0 but cell empty: clears T0, picks T0, verifies
-#    - G28 Z with tool on the cell and active_tool -1: errors
-#    - G28 Z with no load cell / uncalibrated: errors
-#    - G28 X Y only: no tool pickup, no Z move
-#    - G28 X with Y unknown: homes Y, then homes X
-#    - G28 X with Y known on dock side: clears to clearance_y, then X
+#  Check:
+#    - G28 with a locked tool: no trip to the dock for T0
+#    - G28 Z with no XY: error
+#    - Empty cell, Z never homed: error (seat by hand)
+#    - Empty cell, Z already homed: pick T0 then probe
+#    - No load cell / uncalibrated: error
+#    - G28 X with Y unknown: homes Y then X
 #
 #####################################################################
 
@@ -79,8 +57,9 @@ gcode:
         G28 Y
     {% endif %}
 
-    # 3. Before X: if Y was already known, ensure clear of docks.
-    # Just-homed Y: endstop is fine for X - home X immediately.
+    # 3. If Y was already homed, stay off the dock before X.
+    # Just-homed Y is already at the endstop. Do not move from the
+    # pre-home Y this template still sees.
     {% if home_x %}
         {% if not home_y %}
             {% set cur_y = printer.toolhead.position.y|float %}
@@ -169,14 +148,10 @@ gcode:
         SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Must home X and Y before Z"'
         _INDX_HOME_Z_FAIL
     {% else %}
-        # Record real Z-homed before fake-home. SAFE_Z_HOP already cleared
-        # unknown Z; an empty cell must not dock-pick T0 on that first home.
+        # Remember whether Z was ever homed. Do not pick T0 at a guessed height.
         {% set z_known = 1 if "z" in printer.toolhead.homed_axes else 0 %}
         SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_known VALUE={z_known}
-        # SAFE_Z_HOP leaves Z unhomed so the final G28 Z actually probes.
-        # Mark Z homed at the current height before CHANGE_TOOL / offsets /
-        # probe XY travel. A non-T0 SET_GCODE_OFFSET plus z_tilt or bed mesh
-        # turns G0 X Y into a Z move, which Klipper rejects while Z is unhomed.
+        # Mark Z homed at the current height so G0 XY is allowed before the probe.
         {% if "z" not in printer.toolhead.homed_axes %}
             SET_KINEMATIC_POSITION SET_HOMED=Z
         {% endif %}
@@ -199,8 +174,7 @@ gcode:
             SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: no tool seated. Seat and lock a tool by hand, then G28 Z."'
             _INDX_HOME_Z_FAIL
         {% else %}
-            # CHANGE_TOOL is a no-op when act already equals TOOL. Stale T0
-            # with an empty cell would otherwise skip pickup.
+            # CHANGE_TOOL T0 does nothing if the saved tool is already 0.
             {% if act == 0 %}
                 SAVE_VARIABLE VARIABLE=active_tool VALUE=-1
             {% endif %}

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -61,6 +61,8 @@ variable_accel_mult: 0.7
 variable_speed_mult: 0.7
 variable_toolhead_state: 0 # 0=Locked, 2=Open
 variable_rotation_dist_overridden: 0
+# Set by [homing_override] so CHANGE_TOOL/PARK_TOOL do not re-enter G28 mid-home.
+variable_homing_busy: 0
 gcode:
 
 [delayed_gcode INIT_STATE]
@@ -312,8 +314,9 @@ gcode:
         {% endif %}
 
         {% if act != t %}
-            # 0. Home if not already homed
-            {% if "xyz" not in printer.toolhead.homed_axes %}
+            # 0. Home if not already homed (skip when called from [homing_override])
+            {% set busy = printer["gcode_macro _TOOLCHANGE_VARS"].homing_busy|default(0)|int %}
+            {% if not busy and "xyz" not in printer.toolhead.homed_axes %}
                 G28
             {% endif %}
 
@@ -378,8 +381,9 @@ gcode:
     {% set zhop = params.ZHOP|default(0.0)|float %}
 
     {% if act != -1 %}
-        # Home if not already homed
-        {% if "xyz" not in printer.toolhead.homed_axes %}
+        # Home if not already homed (skip when called from [homing_override])
+        {% set busy = printer["gcode_macro _TOOLCHANGE_VARS"].homing_busy|default(0)|int %}
+        {% if not busy and "xyz" not in printer.toolhead.homed_axes %}
             G28
         {% endif %}
 

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -57,9 +57,17 @@ variable_probe_y:          -1.0   # set to bed centre Y, or -1 to auto-detect
 variable_probe_fuzz:         2.0
 variable_probe_z_clearance: 10.0
 
+# ── Homing seat check ────────────────────────────────────────────────────────
+#  home_min_force_g = absolute grams (force_g + tare_force) required
+#                     before G28 Z. Empty head sits well below this.
+#                     Raise if an empty head is accepted as seated;
+#                     lower only if a seated tool is refused.
+variable_home_min_force_g: 800.0
+
 # ── Dock approach direction ──────────────────────────────────────────────────
 #  dock_dir = Y sign into the dock: -1 front (min Y), +1 rear (max Y).
-#             Flips trigger line, unlock depths, and peel relative to dock_y.
+#             Flips trigger line, unlock depths, peel, and the homing
+#             X-clearance check relative to dock_y.
 variable_dock_dir: -1
 
 # ── Trigger offset ───────────────────────────────────────────────────────────

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -58,8 +58,8 @@ variable_probe_fuzz:         2.0
 variable_probe_z_clearance: 10.0
 
 # ── Homing seat check ────────────────────────────────────────────────────────
-#  home_min_force_g = absolute grams (force_g + tare_force) required
-#                     before G28 Z. Empty head sits well below this.
+#  home_min_force_g = grams the load cell must show before G28 Z.
+#                     Empty head sits well below this.
 #                     Raise if an empty head is accepted as seated;
 #                     lower only if a seated tool is refused.
 variable_home_min_force_g: 800.0


### PR DESCRIPTION
The README has pointed at `homing.cfg` for a while (Y before X, then Z with a nozzle on the cell) but the file was never in the repo, so stock `G28` still homes X first and can sweep the dock. This adds it. Closes #8.

Z homing does not trust the saved tool number. That value can be wrong both ways: empty while a tool is still in the head, or seated after a partial release (the "retract before 3mm+ extrusion" case). Before any T0 pickup or probe, the load cell has to show a seated tool (`home_min_force_g` in `indx.cfg`, default 800). No cell, or an uncalibrated cell, is an error. A loaded cell with no known tool is also an error.

`G28 Z` homes with the seated tool, not always T0, as there is no reason for that restriction.