### PR TITLE
Clear the provisional Z home when Z homing fails

### DIFF
--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -79,6 +79,12 @@ gcode:
 
 [gcode_macro _INDX_SAFE_Z_HOP]
 description: Inner - clear Z to probe_z_clearance before any axis home
+# The hop runs before Y moves, which means a head sitting inside the dock at
+# real Y < clearance_y lifts into a docked tool. Moving Y first instead would
+# drag the nozzle across the bed whenever real Z is near 0. The hop wins: it
+# can reach one tool at most, and the stock docks allow the tool some Z travel
+# by design, where a bed scrape is permanent. Swap the two if your machine
+# makes the opposite trade.
 gcode:
     {% set tp = printer["gcode_macro TOOL_POSITIONS"] %}
     {% set z_clr = tp.probe_z_clearance|float %}
@@ -122,7 +128,8 @@ gcode:
         {% if not lc.is_calibrated|default(false) or fg is none %}
             {% set ns.err = "Cannot home Z: load cell is not calibrated" %}
         {% else %}
-            {% set ns.force = fg|float + lc.tare_force|default(0.0)|float %}
+            # force_g is already relative to the tare, so it is the seat reading as-is
+            {% set ns.force = fg|float %}
             {% if ns.force|abs >= min_g %}
                 {% set ns.ok = 1 %}
             {% endif %}
@@ -143,7 +150,9 @@ gcode:
 [gcode_macro _INDX_HOME_Z]
 description: Inner - load-cell verify, then keep seated tool or pick T0, then probe Z
 variable_z_known: 0
+variable_z_faked: 0
 gcode:
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=0
     {% if "xy" not in printer.toolhead.homed_axes %}
         SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Must home X and Y before Z"'
         _INDX_HOME_Z_FAIL
@@ -154,6 +163,7 @@ gcode:
         # Mark Z homed at the current height so G0 XY is allowed before the probe.
         {% if "z" not in printer.toolhead.homed_axes %}
             SET_KINEMATIC_POSITION SET_HOMED=Z
+            SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=1
         {% endif %}
         _INDX_HOME_VERIFY NEXT=soft
     {% endif %}
@@ -221,15 +231,24 @@ gcode:
     G90
     G0 X{"%.3f"|format(px)} Y{"%.3f"|format(py)} F3000
     G28 Z
+    SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=0
     {% set act = printer.save_variables.variables.active_tool|default(-1)|int %}
     SAVE_VARIABLE VARIABLE=z_home_tool VALUE={act}
     SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
 
 [gcode_macro _INDX_HOME_Z_FAIL]
-description: Inner - clear homing_busy then raise (raise aborts template eval)
+description: Inner - drop the provisional Z home, clear homing_busy, then raise
 variable_msg: ""
 gcode:
     SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
+    # _INDX_HOME_Z marks Z homed at the hop height so it can move to the probe
+    # XY. That height is a guess. If we never reached the probe, clear it again,
+    # otherwise the axis reports homed at a made-up origin and the next G0 Z
+    # drives the nozzle into the bed.
+    {% if printer["gcode_macro _INDX_HOME_Z"].z_faked|int %}
+        SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=0
+    {% endif %}
     _INDX_HOME_Z_FAIL_RAISE
 
 [gcode_macro _INDX_HOME_Z_FAIL_RAISE]


### PR DESCRIPTION
Follow-up to #53.

`_INDX_HOME_Z` marks Z homed at the hop height so it can travel to the probe XY before the real probe happens. Every failure path after that point raised without clearing the mark again, so a refused seat check (no tool, uncalibrated cell, unknown tool) left the axis reporting homed at a height that was never measured. The next `G0 Z` would then drive the nozzle into the bed on a Z origin that is a guess.

This tracks whether the homed mark was ours and drops it again on the failure path, so a failed `G28 Z` leaves Z unhomed rather than falsely homed.

Two smaller things in the same file:

The seat check added `tare_force` to `force_g`. `force_g` is already relative to the tare and `tare_force` is not a status field, so the term was always zero. Dropped it so the reading reads as what it is.

Documented the hop-before-Y ordering trade in `_INDX_SAFE_Z_HOP`. Hopping first can lift a docked tool if the head is sitting inside the dock; moving Y first would scrape the bed whenever real Z is near zero. The hop is the better trade and the reasoning should be in the file rather than rediscovered. That reasoning is codur-design's, from #50.