### PR TITLE
Fix OrcaSlicer toolchange temperature, and support tools that do not heat

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,8 @@ Copy the path that starts with `usb-Bondtech_INDX` and paste it into your config
 
 The `[extruder]` block above is always required and represents the Smart Head's single DX extruder. INDX passive tools are **not** separate Klipper extruders — there is only ever one `[extruder]`. Additional tools (T1, T2, …) are defined in `indx.cfg`: set `variable_tool_count` and add a `variable_t{n}_x` / `variable_t{n}_dock_y` pair per tool in the `[gcode_macro TOOL_POSITIONS]` section (see [INDX macro files](#indx-macro-files)). Per-tool XY/Z offsets come from [Tool Offsets](#tool-offsets) calibration, and per-tool nozzle sizes and temperatures are set in your slicer.
 
+**Tools that do not print.** A dock position does not have to hold a hotend. If you are carrying a pen, a cutter, a camera or anything else with nothing to heat, list its tool number in `variable_no_heat_tools` in `indx.cfg`, for example `variable_no_heat_tools: [3]`. The pickup, latch and park moves already run cold, so the only thing that changes is that the induction coil is never switched on for that tool. Setting it here rather than in the slicer matters: your change filament G-code is a single template shared by every tool, so it will pass a temperature for the pen along with everything else, and this makes the printer ignore it. The tool still needs a dock position and still counts toward `variable_tool_count`.
+
 ##### INDX macro files
 
 The INDX firmware plugin provides a set of `.cfg` files you include from `printer.cfg`. Each file has a specific role:

--- a/README.md
+++ b/README.md
@@ -1527,11 +1527,15 @@ Common slicers used with INDX include PrusaSlicer, OrcaSlicer, SuperSlicer, and 
 
   Add under Printer Settings → Machine G-code → Change filament G-code:
   ```gcode
-  CHANGE_TOOL TOOL={next_extruder} TEMP={nozzle_temperature[next_extruder]}
+  CHANGE_TOOL TOOL={next_extruder} TEMP={new_filament_temp}
   M400
   ```
 
   `TEMP=` tells the toolchange what the incoming tool should heat to. Without it the macro can only fall back to the outgoing tool's temperature, which is correct when both tools print at the same temperature and wrong when they don't: the new tool gets brought to the old filament's temperature and only corrected afterwards. Passing it heats each tool to its own temperature once, with no overshoot and no second wait.
+
+  > ⚠️ **Use `new_filament_temp`, not `nozzle_temperature[next_extruder]`.** Inside OrcaSlicer's Change filament G-code the per-filament temperature arrays do not resolve to the value you asked for; users report getting the filament's **Recommended nozzle temperature → Max** instead, and `nozzle_temperature_initial_layer` and `first_layer_temperature` are affected the same way. The same placeholders are fine in Machine start G-code, which is why this is easy to miss. `new_filament_temp` is a plain value OrcaSlicer computes for the incoming filament rather than an array you index yourself, so there is no index to resolve wrongly. It is also first-layer aware, giving the first layer temperature on layer one and the other-layers temperature after that, which is what you want in a toolchange. Earlier versions of this README used the array form; if you copied it, change it.
+
+  Setting **Recommended nozzle temperature → Max** equal to your printing temperature also works, but it edits a real setting to work around a slicer bug and has to be repeated for every filament, so prefer `new_filament_temp`.
 
   **PrusaSlicer / SuperSlicer**
 

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -336,7 +336,11 @@ gcode:
             #    the two tools run different materials. Without it all we have is
             #    the outgoing tool's target, which is right when both tools print
             #    at the same temperature and wrong when they don't.
-            {% set target_temp = params.TEMP|default(printer.extruder.target)|float %}
+            #    A slicer placeholder that resolves to nothing arrives as 0, which
+            #    would silently print the rest of the job with the heater off, so
+            #    treat anything at or below zero as "not supplied" and fall back.
+            {% set temp_param = params.TEMP|default(-1)|float %}
+            {% set target_temp = temp_param if temp_param > 0 else printer.extruder.target|float %}
             M104 S0
             
             # 4. Z-Sync before moving

--- a/macros/indx-tc-macros.cfg
+++ b/macros/indx-tc-macros.cfg
@@ -339,8 +339,15 @@ gcode:
             #    A slicer placeholder that resolves to nothing arrives as 0, which
             #    would silently print the rest of the job with the heater off, so
             #    treat anything at or below zero as "not supplied" and fall back.
+            #    Tools listed in no_heat_tools carry no hotend, so they are never
+            #    heated whatever the slicer asks for. Deciding that here rather
+            #    than from a bare TEMP=0 keeps it out of the slicer's hands: the
+            #    change filament G-code is one template for every tool and will
+            #    happily pass a temperature for the pen as well.
+            {% set no_heat = t in tp.no_heat_tools|default([]) %}
             {% set temp_param = params.TEMP|default(-1)|float %}
-            {% set target_temp = temp_param if temp_param > 0 else printer.extruder.target|float %}
+            {% set target_temp = 0.0 if no_heat
+                else (temp_param if temp_param > 0 else printer.extruder.target|float) %}
             M104 S0
             
             # 4. Z-Sync before moving

--- a/macros/indx.cfg
+++ b/macros/indx.cfg
@@ -103,6 +103,15 @@ variable_t2_dock_y: -26
 variable_t3_x:     102.0
 variable_t3_dock_y: -26
 
+# ── Tools that must never be heated ──────────────────────────────────────────
+#  no_heat_tools = list of tool numbers that carry no hotend: a pen, a cutter,
+#                  a camera, anything that is not a printing tool. CHANGE_TOOL
+#                  picks these up and parks them like any other tool but never
+#                  turns the coil on for them, whatever temperature the slicer
+#                  asks for. Leave empty if every tool prints.
+#                  Example for a pen in dock 3:  variable_no_heat_tools: [3]
+variable_no_heat_tools: []
+
 # ── Assembled at startup from the variables above — do not edit ──────────────
 variable_tools: []
 


### PR DESCRIPTION
Fixes the temperature handling reported in #56, and finishes what 21ddd54 started for #42.

`nozzle_temperature[next_extruder]` does not resolve correctly inside OrcaSlicer's Change filament G-code. Users get the filament's **Recommended nozzle temperature → Max** instead of its printing temperature, so every toolchange heats to the wrong target. `nozzle_temperature_initial_layer` and `first_layer_temperature` are affected the same way, and the same names work fine in Machine start G-code, which is what makes it hard to spot. Upstream: OrcaSlicer/OrcaSlicer#15405 and OrcaSlicer/OrcaSlicer#15044, both unresolved.

The snippet now uses `{new_filament_temp}`. OrcaSlicer computes that value itself for the incoming filament and injects it as a plain integer, so there is no array for the snippet to index wrongly. It is first-layer aware, giving the first layer temperature on layer one and the other-layers temperature after that. OrcaSlicer's own shipped Bambu and Elegoo profiles use it in this same block, and it is present and unconditional in 2.4.2 as well as current main, so this is not a nightly-only fix.

This is a real fix rather than the max-temperature workaround in #56, which edits a genuine setting to dodge a slicer bug and has to be repeated for every filament. The README mentions that workaround as a fallback and says why to prefer this.

PrusaSlicer and SuperSlicer are unaffected; `temperature[next_extruder]` works there and is unchanged.

### Non-printing tools

`CHANGE_TOOL` used `params.TEMP|default(...)`, which only falls back when the parameter is **absent**. A slicer placeholder that resolves to nothing arrives as `TEMP=0`, which passed straight through as the target. Combined with the `M104 S0` at the start of the swap and `_PICKUP_TOOL`'s existing `TARGET > 0` guard on the `M109`, the result is that the tool is never reheated and the rest of the job prints with the heater off. `TEMP` at or below zero is now treated as not supplied.

That removes `TEMP=0` as a way of saying "pick this tool up cold", which is worth having for a tool with nothing to heat: a pen, a cutter, a camera. So this adds it properly, as `no_heat_tools` in `indx.cfg`:

```ini
variable_no_heat_tools: [3]
```

Tools listed there are picked up, latched and parked like any other tool, but the coil is never switched on for them whatever the slicer asks for.

Per tool rather than per call, because the change filament G-code is one template shared by every tool. It will pass a temperature for the pen along with everything else, so a `COLD=1` parameter would leave no way to suppress heating for one tool only without hand-editing the slicer template into a conditional. Declaring it on the printer means the printer ignores what the slicer says for that tool.

Almost nothing was needed to make this work, because the mechanism is already cold throughout. `_TC_LATCH_MOVE` bypasses `min_extrude_temp` by design, `PARK_TOOL` kills the heater regardless, `_PICKUP_TOOL` only heats when a target is set, and `_APPLY_TOOL_FILAMENT` no-ops for a tool with no recorded filament. The only missing piece was a way to declare the intent.
