### PR TITLE
Fix XY offset save moving an already-aligned tool

### DIFF
--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -111,7 +111,7 @@ gcode:
         {% set off_y = 0.0 if act == 0 else (printer.toolhead.position.y - svv.cam_pos_y|float) %}
         SAVE_VARIABLE VARIABLE=t{act}_offset_x VALUE='{"%.3f"|format(off_x)}'
         SAVE_VARIABLE VARIABLE=t{act}_offset_y VALUE='{"%.3f"|format(off_y)}'
-        SET_GCODE_OFFSET X={"%.3f"|format(off_x)} Y={"%.3f"|format(off_y)} MOVE=1
+        SET_GCODE_OFFSET X={"%.3f"|format(off_x)} Y={"%.3f"|format(off_y)}
         RESPOND MSG="T{act} XY offset saved — X={'%.3f'|format(off_x)}  Y={'%.3f'|format(off_y)}"
     {% else %}
         RESPOND TYPE=error MSG="No tool loaded."


### PR DESCRIPTION
## Summary

Remove `MOVE=1` from the final `SET_GCODE_OFFSET` command in `CAL_03_SAVE_XY_OFFSET`.

By the time this macro runs, the operator has already jogged the nozzle onto the camera reference point. Since `CAL_02_PREP_TOOL_CAL` previously cleared the active offsets, applying the calculated offset with `MOVE=1` moves the already-aligned toolhead by the full offset a second time.

This leaves the nozzle at:

```text
camera position + 2 × calculated offset
```

The saved offset values themselves are correct; only the physical movement after saving is incorrect.

## Fix

Update the coordinate system without moving the toolhead:

```gcode
SET_GCODE_OFFSET X={"%.3f"|format(off_x)} Y={"%.3f"|format(off_y)}
```

The `MOVE=1` in `CAL_02_PREP_TOOL_CAL` remains unchanged because that movement is intentional when clearing the previous offsets before calibration.

## Testing

Previously tested on a six-tool INDX setup before this change was submitted:

- Saving a non-zero XY offset caused no physical movement.
- The nozzle remained aligned with the camera reference.
- The resulting G-code position matched the saved camera position within 0.0004 mm.

This PR applies the same one-line change that was used for that physical test.

## Related changes

PR #43 renames this macro to `CAL_THREE_SAVE_XY_OFFSET`. This PR retains the current name from `main`; whichever PR merges second may need to resolve the macro-name context while preserving this change.

Closes #62.
