### PR TITLE
Follow the camera macro rename through, and document the recovery macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
    - [Tool Offsets](#tool-offsets)
      - [Method 1: Print and adjust](#method-1-print-and-adjust-free-no-extra-hardware)
      - [Method 2: Nudge](#method-2-nudge-automatic-requires-small-hardware)
-     - [Method 3: Nozzle camera + CAL_01/02/03](#method-3-nozzle-camera-most-precise-xy-higher-cost)
+     - [Method 3: Nozzle camera + CAL_ONE/TWO/THREE](#method-3-nozzle-camera-most-precise-xy-higher-cost)
      - [Z offset: CAL_Z](#z-offset-calibration)
    - [Temperature & Induction Settings](#temperature--induction-settings)
    - [Speed & Acceleration](#speed--acceleration)
@@ -1349,23 +1349,23 @@ Nudge is highly repeatable, typically below 0.003mm standard deviation over 10 s
 
 A nozzle-mounted or fixed camera system (e.g. [Axiscope](https://github.com/nic335/Axiscope)) lets you visually align tools with sub-micron precision. Offsets are derived from image analysis rather than physical contact.
 
-The INDX macro package includes a built-in camera calibration workflow (`CAL_01` → `CAL_02` → `CAL_03`) that automates the offset calculation once a camera is set up.
+The INDX macro package includes a built-in camera calibration workflow (`CAL_ONE` → `CAL_TWO` → `CAL_THREE`) that automates the offset calculation once a camera is set up.
 
 **Workflow:**
 
 1. Pick up T0 and jog the nozzle tip to the centre of your camera crosshair. Run:
    ```gcode
-   CAL_01_SET_CAMERA_REF
+   CAL_ONE_SET_CAMERA_REF
    ```
    This saves the current position as the reference point.
 
 2. For each additional tool, run:
    ```gcode
-   CAL_02_PREP_TOOL_CAL TOOL=1
+   CAL_TWO_PREP_TOOL_CAL TOOL=1
    ```
    The macro picks up the tool and moves it to the camera position. Re-centre the nozzle in the crosshair using the jog controls, then run:
    ```gcode
-   CAL_03_SAVE_XY_OFFSET
+   CAL_THREE_SAVE_XY_OFFSET
    ```
    The offset is calculated and saved automatically. Repeat for every additional tool.
 
@@ -1805,6 +1805,26 @@ If the Smart Head has crashed into the dock, a tool, or part of the printer fram
 Visually inspect the Smart Head for any obvious physical damage: bent parts, broken clips, or anything that looks out of position. Do not attempt to force the mechanism open or closed if it is stuck.
 
 If hardware damage is confirmed or suspected, contact Bondtech support at [bondtech.se/contact](https://www.bondtech.se/contact/) before continuing to use the system. Running with a damaged DX extruder can cause print failures and may cause further damage.
+
+### INDX has the wrong idea of which tool is loaded
+
+After a power cut mid-toolchange, a crash, or a tool that was pulled off by hand, the saved state can disagree with reality: INDX believes a tool is locked when the head is empty, or believes it is empty when a tool is still in. Symptoms are a tool change that refuses to run, a `G28 Z` that errors on the load-cell seat check, or `TOOL_STATUS` showing a tool you know is not there.
+
+Two macros exist to get out of it. Both are deliberately blunt, so read what they do before running either.
+
+```gcode
+MANUAL_TOOL_REMOVE
+```
+
+Opens the latch so you can take the tool off by hand, then records the head as open and empty. **The tool is released the moment the latch opens**, so support it with your hand first or it will drop. Use this when a tool is physically in the head and you want it out.
+
+```gcode
+MANUAL_TOOLHEAD_RESET
+```
+
+Records the head as open and empty without touching the latch. Use this when the head is *already* empty and only the saved state is wrong. It changes what INDX believes, not what the hardware is doing, so running it while a tool is still locked in leaves the two further apart than before.
+
+After either one, pick a tool up normally with `Tn` or `CHANGE_TOOL` and the state will be correct again from there. If the latch itself will not move, stop and see [DX extruder not opening or closing correctly after a crash](#dx-extruder-not-opening-or-closing-correctly-after-a-crash) rather than forcing it.
 
 ### `indxmcu` not connecting
 

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -19,9 +19,9 @@
 #                              Already homed? Jog to the dock and read the
 #                              current X directly.
 #
-#  2. XY tool offsets        CAL_01_SET_CAMERA_REF
-#     (camera method)        CAL_02_PREP_TOOL_CAL TOOL=N
-#                            CAL_03_SAVE_XY_OFFSET
+#  2. XY tool offsets        CAL_ONE_SET_CAMERA_REF
+#     (camera method)        CAL_TWO_PREP_TOOL_CAL TOOL=N
+#                            CAL_THREE_SAVE_XY_OFFSET
 #
 #  3. Z auto-calibration     CAL_Z
 #     (convergent + median)    Convergence window + median sampling.
@@ -69,11 +69,11 @@ gcode:
 #####################################################################
 #
 #  Step 1: Pick up T0, jog it so the nozzle tip is centred in your
-#          camera crosshair, then run CAL_01_SET_CAMERA_REF.
-#  Step 2: For each additional tool, run CAL_02_PREP_TOOL_CAL TOOL=N.
+#          camera crosshair, then run CAL_ONE_SET_CAMERA_REF.
+#  Step 2: For each additional tool, run CAL_TWO_PREP_TOOL_CAL TOOL=N.
 #          The tool is picked up and moved to the camera position.
 #          Jog to re-centre it in the crosshair.
-#  Step 3: Run CAL_03_SAVE_XY_OFFSET to save the offset and snap
+#  Step 3: Run CAL_THREE_SAVE_XY_OFFSET to save the offset and snap
 #          back to verify alignment.
 #
 #####################################################################
@@ -96,9 +96,9 @@ gcode:
         _CAL_LATCH_ENGAGE
         SET_GCODE_OFFSET X=0 Y=0 Z=0 MOVE=1
         _CAL_GOTO_CAMPOS
-        RESPOND MSG="Align T{t} in crosshair, then run CAL_03_SAVE_XY_OFFSET"
+        RESPOND MSG="Align T{t} in crosshair, then run CAL_THREE_SAVE_XY_OFFSET"
     {% else %}
-        RESPOND TYPE=error MSG="Usage: CAL_02_PREP_TOOL_CAL TOOL=1"
+        RESPOND TYPE=error MSG="Usage: CAL_TWO_PREP_TOOL_CAL TOOL=1"
     {% endif %}
 
 [gcode_macro CAL_THREE_SAVE_XY_OFFSET]
@@ -122,7 +122,7 @@ description: Inner — move to saved camera reference position
 gcode:
     {% set svv = printer.save_variables.variables %}
     {% if 'cam_pos_x' not in svv or 'cam_pos_y' not in svv or 'cam_pos_z' not in svv %}
-        {action_raise_error("Camera reference missing. Run CAL_01_SET_CAMERA_REF first.")}
+        {action_raise_error("Camera reference missing. Run CAL_ONE_SET_CAMERA_REF first.")}
     {% endif %}
     {% set cx = svv.cam_pos_x|float %}
     {% set cy = svv.cam_pos_y|float %}

--- a/macros/indx-cal.cfg
+++ b/macros/indx-cal.cfg
@@ -73,8 +73,9 @@ gcode:
 #  Step 2: For each additional tool, run CAL_TWO_PREP_TOOL_CAL TOOL=N.
 #          The tool is picked up and moved to the camera position.
 #          Jog to re-centre it in the crosshair.
-#  Step 3: Run CAL_THREE_SAVE_XY_OFFSET to save the offset and snap
-#          back to verify alignment.
+#  Step 3: Run CAL_THREE_SAVE_XY_OFFSET to save the offset. The
+#          nozzle stays exactly where you aligned it; only the
+#          coordinate system shifts.
 #
 #####################################################################
 


### PR DESCRIPTION
Follow-up to #64 and #65, both merged.

#64 renamed the three camera calibration macros so Klipper can actually parse them, which was the real fix. It changed the `[gcode_macro ...]` headers only, and eight further references in `indx-cal.cfg` plus five in the README still named `CAL_01` / `CAL_02` / `CAL_03`.

Three of those are user facing and would have been actively misleading:

- `Align T{t} in crosshair, then run CAL_03_SAVE_XY_OFFSET`
- `Usage: CAL_02_PREP_TOOL_CAL TOOL=1`
- `Camera reference missing. Run CAL_01_SET_CAMERA_REF first.`

Each names a command that no longer exists, and the README walkthrough told people to type all three. Anyone following the documented workflow would have hit the same "unknown command" failure the rename was meant to cure, so the fix needed the references to land with it.

#65 added `MANUAL_TOOL_REMOVE` and `MANUAL_TOOLHEAD_RESET`, which were not documented anywhere. They are the recovery path for a saved state that disagrees with the hardware, which is exactly the situation someone is in after a power cut mid-change or a tool pulled off by hand, so there is now a troubleshooting entry for it.

The two macros are easy to confuse and the consequence of picking wrong is a tool hitting the bed, so the entry is explicit: `MANUAL_TOOL_REMOVE` opens the latch and releases the tool the moment it does, support it by hand first; `MANUAL_TOOLHEAD_RESET` only rewrites what INDX believes and is for a head that is already empty.

Also restores the trailing newline `indx-cal.cfg` lost in #65.