### PR TITLE
List the Voron 2.4 community parts set

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ INDX runs on a wide range of CoreXY printers, far more than Bondtech could ever 
 
 > **What does "community" status mean?** The hardware works on that printer, but the integration guide comes from the community, not Bondtech. Some printers already have complete, verified configs on GitHub; check the repo first. Others are earlier stage. The [Bondtech Discord](https://discord.gg/XDX9jDXN6e) has channels for specific printers, which is a good place to find others running the same platform and see how far along the integration is.
 
+> ⚠️ **Anything linked below as unverified has not been checked by Bondtech.** We have not printed the parts, measured them, or run them on a machine here. They are listed because they look like a useful starting point and because the alternative is you finding nothing at all, not because we are vouching for them. Read them the way you would read any stranger's remix: check the geometry against [Dock Design](#dock-design) before you print a dock, and expect to verify rather than trust. Questions about those parts belong with whoever made them.
+
 | Printer | Status | Notes |
 | ------- | ------ | ----- |
-| Voron 2.4 | Community | |
+| Voron 2.4 | Community | Unverified parts set: [karasgit/INDX-for-Voron-2.4](https://github.com/karasgit/INDX-for-Voron-2.4), with a [walkthrough video](https://www.youtube.com/watch?v=topIOL-b3Gw) by Emplikac 000 |
 | Voron Trident | Community | Trident R2 has an [officially recognized integration](#officially-recognized-integrations) |
 | RatRig V-Core | Community | |
 | Sovol | Community | SV08 OG / SV08 Max have an [officially recognized integration](#officially-recognized-integrations) |


### PR DESCRIPTION
The Voron 2.4 row in the community integrations table had no notes, despite it being one of the most likely printers someone arrives with.

Adds [karasgit/INDX-for-Voron-2.4](https://github.com/karasgit/INDX-for-Voron-2.4), a full parts set covering the X-carriage, tool holder, XY joint, front idlers, Z bearing block with Y endstop and Z chain mount, along with the [walkthrough video](https://www.youtube.com/watch?v=topIOL-b3Gw) by Emplikac 000 that the repository is linked from. GPL-3.0, last pushed 2026-09-01.

Listed explicitly as **unverified**, and there is now a note above the table defining what that means, because the existing "what does community status mean" note does not cover it. That note says the hardware works and the guide comes from the community, which is a weaker claim than linking to specific printable parts we have never seen.

The new note says plainly that Bondtech has not printed, measured or run these parts, that they are listed as a starting point rather than an endorsement, and that questions belong with whoever made them. It also points people at [Dock Design](#dock-design) before printing a dock, since dock geometry that misses those constraints produces unreliable tool changes rather than an obvious failure.

Worth a look at the wording before this goes in, since it is the first time the README points at third-party printable parts without recognizing them.