### PR TITLE
Separate unverified community builds from printer compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,19 +199,27 @@ They are not Bondtech products. They are hosted externally and maintained by the
 | Sovol SV08 OG & SV08 Max | 3DPrintDemon | [Printables](https://www.printables.com/model/1771164-official-indx-sovol-sv08-og-sv08-max-integrations) |
 | Voron Trident R2 | Steve — Voron team, designer of the Trident | [Printables](https://www.printables.com/model/1761163-trident-r2-bondtech-indx-mods) |
 
-### Community integrations
+### Unverified community builds
+
+Other people have published complete conversions that nobody at Bondtech has been through. They are listed here because a starting point you have to check is worth more than no starting point at all.
+
+> ⚠️ **Nothing in this table has been checked by Bondtech.** We have not printed these parts, measured them, or run them on a machine here. Listing them is not an endorsement and says nothing about whether the geometry is right. Read them the way you would read any stranger's remix: check a dock against [Dock Design](#dock-design) before printing it, since dock geometry that misses those constraints gives unreliable tool changes rather than an obvious failure. Questions about these parts belong with whoever made them, not with Bondtech.
+
+| Printer | Build | Source |
+| ------- | ----- | ------ |
+| Voron 2.4 | Full conversion parts set: X-carriage, tool holder, XY joint, front idlers, Z bearing block with Y endstop, Z chain mount | [karasgit/INDX-for-Voron-2.4](https://github.com/karasgit/INDX-for-Voron-2.4), with a [walkthrough video](https://www.youtube.com/watch?v=topIOL-b3Gw) by Emplikac 000 |
+
+### Printer compatibility
 
 INDX runs on a wide range of CoreXY printers, far more than Bondtech could ever test and support directly. What makes that possible is community members who've done the integration work on their own printer and shared what they learned. Every config in the repo started with someone doing it for the first time.
 
 > **What does "community" status mean?** The hardware works on that printer, but the integration guide comes from the community, not Bondtech. Some printers already have complete, verified configs on GitHub; check the repo first. Others are earlier stage. The [Bondtech Discord](https://discord.gg/XDX9jDXN6e) has channels for specific printers, which is a good place to find others running the same platform and see how far along the integration is.
 
-> ⚠️ **Anything linked below as unverified has not been checked by Bondtech.** We have not printed the parts, measured them, or run them on a machine here. They are listed because they look like a useful starting point and because the alternative is you finding nothing at all, not because we are vouching for them. Read them the way you would read any stranger's remix: check the geometry against [Dock Design](#dock-design) before you print a dock, and expect to verify rather than trust. Questions about those parts belong with whoever made them.
-
-| Printer | Status | Notes |
-| ------- | ------ | ----- |
-| Voron 2.4 | Community | Unverified parts set: [karasgit/INDX-for-Voron-2.4](https://github.com/karasgit/INDX-for-Voron-2.4), with a [walkthrough video](https://www.youtube.com/watch?v=topIOL-b3Gw) by Emplikac 000 |
+| Printer | Status | Parts available |
+| ------- | ------ | --------------- |
+| Voron 2.4 | Community | [Unverified build](#unverified-community-builds) |
 | Voron Trident | Community | Trident R2 has an [officially recognized integration](#officially-recognized-integrations) |
-| RatRig V-Core | Community | |
+| RatRig V-Core | Community | None published yet |
 | Sovol | Community | SV08 OG / SV08 Max have an [officially recognized integration](#officially-recognized-integrations) |
 | Custom CoreXY | Community | Any CoreXY with open firmware; see [Requirements](#requirements--preparation) |
 

--- a/README.md
+++ b/README.md
@@ -201,27 +201,17 @@ They are not Bondtech products. They are hosted externally and maintained by the
 
 ### Unverified community builds
 
-Other people have published complete conversions that nobody at Bondtech has been through. They are listed here because a starting point you have to check is worth more than no starting point at all.
+INDX runs on a wide range of CoreXY printers, far more than Bondtech could ever test and support directly. What makes that possible is community members who've done the integration work on their own printer and shared what they learned. The printers below are known to work; what varies is whether anyone has published parts for them yet.
 
-> ⚠️ **Nothing in this table has been checked by Bondtech.** We have not printed these parts, measured them, or run them on a machine here. Listing them is not an endorsement and says nothing about whether the geometry is right. Read them the way you would read any stranger's remix: check a dock against [Dock Design](#dock-design) before printing it, since dock geometry that misses those constraints gives unreliable tool changes rather than an obvious failure. Questions about these parts belong with whoever made them, not with Bondtech.
+> ⚠️ **Nothing in this table has been checked by Bondtech.** We have not printed these parts, measured them, or run them on a machine here. Listing a build is not an endorsement and says nothing about whether the geometry is right. Read them the way you would read any stranger's remix: check a dock against [Dock Design](#dock-design) before printing it, since dock geometry that misses those constraints gives unreliable tool changes rather than an obvious failure. Questions about these parts belong with whoever made them, not with Bondtech.
 
 | Printer | Build | Source |
 | ------- | ----- | ------ |
 | Voron 2.4 | Full conversion parts set: X-carriage, tool holder, XY joint, front idlers, Z bearing block with Y endstop, Z chain mount | [karasgit/INDX-for-Voron-2.4](https://github.com/karasgit/INDX-for-Voron-2.4), with a [walkthrough video](https://www.youtube.com/watch?v=topIOL-b3Gw) by Emplikac 000 |
+| RatRig V-Core | None published yet | — |
+| Custom CoreXY | None, and none expected: mounting is specific to your machine | Any CoreXY with open firmware works; see [Requirements](#requirements--preparation) |
 
-### Printer compatibility
-
-INDX runs on a wide range of CoreXY printers, far more than Bondtech could ever test and support directly. What makes that possible is community members who've done the integration work on their own printer and shared what they learned. Every config in the repo started with someone doing it for the first time.
-
-> **What does "community" status mean?** The hardware works on that printer, but the integration guide comes from the community, not Bondtech. Some printers already have complete, verified configs on GitHub; check the repo first. Others are earlier stage. The [Bondtech Discord](https://discord.gg/XDX9jDXN6e) has channels for specific printers, which is a good place to find others running the same platform and see how far along the integration is.
-
-| Printer | Status | Parts available |
-| ------- | ------ | --------------- |
-| Voron 2.4 | Community | [Unverified build](#unverified-community-builds) |
-| Voron Trident | Community | Trident R2 has an [officially recognized integration](#officially-recognized-integrations) |
-| RatRig V-Core | Community | None published yet |
-| Sovol | Community | SV08 OG / SV08 Max have an [officially recognized integration](#officially-recognized-integrations) |
-| Custom CoreXY | Community | Any CoreXY with open firmware; see [Requirements](#requirements--preparation) |
+The [Bondtech Discord](https://discord.gg/XDX9jDXN6e) has channels for specific printers, which is the best place to find someone running the same platform and ask how far along they got.
 
 **Your printer isn't listed?** If you've got INDX running on it, that integration belongs here. Submit a pull request on [github.com/BondtechAB/INDX](https://github.com/BondtechAB/INDX) and you'll save the next person hours of work. See [Contributing a printer integration](#contributing-a-printer-integration) for what to include.
 


### PR DESCRIPTION
Splits the integrations area into three sections, ordered strongest claim first:

1. **Officially recognized integrations** — unchanged
2. **Unverified community builds** — new, currently the Voron 2.4 parts set
3. **Printer compatibility** — the platform support list, renamed from Community integrations

The old Community integrations section was one table doing two jobs. Most rows only answer "does INDX run on this printer", while the Voron 2.4 row pointed at specific printable parts nobody has checked. Those carry very different weight and the warning about unverified parts was sitting above a table that was mostly not about parts at all.

The warning now lives with the table it describes, and says plainly that nothing there has been printed, measured or run by Bondtech, that listing is not endorsement, and that questions go to whoever made the parts. The dock geometry pointer stays, since a dock that misses those constraints gives unreliable tool changes rather than failing obviously.

The compatibility table keeps its role as the single place to look up a printer. Its Notes column becomes **Parts available** and cross-references the other two sections rather than carrying the detail itself. RatRig V-Core now reads "None published yet" instead of being blank, which was ambiguous between nothing exists and nobody filled it in.

No links broken: the old `### Community integrations` heading had nothing pointing at it, and all anchors and relative paths validate.