### PR TITLE
fix: macros - stop nested _INDX_HOME_VERIFY

### DIFF
--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -117,12 +117,12 @@ gcode:
     {% set ns = namespace(ok=0, force=0.0, err="") %}
 
     {% if 'load_cell_probe' not in printer %}
-        {% set ns.err = "Cannot home Z: [load_cell_probe] is not loaded" %}
+        {% set ns.err = "Cannot home Z: [load_cell_probe] is missing. Add it to printer.cfg, FIRMWARE_RESTART, then G28." %}
     {% else %}
         {% set lc = printer.load_cell_probe %}
         {% set fg = lc.force_g|default(none) %}
         {% if not lc.is_calibrated|default(false) or fg is none %}
-            {% set ns.err = "Cannot home Z: load cell is not calibrated" %}
+            {% set ns.err = "Cannot home Z: load cell is not calibrated. Follow the Load cell calibration procedure in indx/README, then G28." %}
         {% else %}
             # force_g is already relative to the tare, so it is the seat reading as-is
             {% set ns.force = fg|float %}
@@ -146,7 +146,7 @@ variable_z_faked: 0
 gcode:
     SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=0
     {% if "xy" not in printer.toolhead.homed_axes %}
-        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Must home X and Y before Z"'
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z until X and Y are homed. Run G28, or G28 X Y then G28 Z."'
         _INDX_HOME_Z_FAIL
     {% else %}
         # Remember whether Z was ever homed. Do not pick T0 at a guessed height.
@@ -172,11 +172,11 @@ gcode:
     {% set z_known = printer["gcode_macro _INDX_HOME_Z"].z_known|int %}
 
     {% if last_ok == 1 and act < 0 %}
-        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: tool detected but active_tool is unknown (-1). Run CHANGE_TOOL or fix latch state."'
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: a tool is on the head but active_tool is unknown. Run CHANGE_TOOL TOOL=<n> for that tool, then G28."'
         _INDX_HOME_Z_FAIL
     {% elif last_ok != 1 %}
         {% if not z_known %}
-            SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: no tool seated. Seat and lock a tool by hand, then G28 Z."'
+            SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: no tool seated, and Z is not homed so the printer will not fetch T0. Seat and lock a tool by hand, then G28 Z."'
             _INDX_HOME_Z_FAIL
         {% else %}
             # CHANGE_TOOL T0 does nothing if the saved tool is already 0.
@@ -204,7 +204,7 @@ description: Inner - after T0 pickup: abort if the cell still does not see a too
 gcode:
     {% set last_ok = printer["gcode_macro _INDX_HOME_VERIFY"].last_ok|int %}
     {% if last_ok != 1 %}
-        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: T0 not seated after pickup"'
+        SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"Cannot home Z: T0 did not seat after pickup. Check the T0 dock, seat T0 by hand or run CHANGE_TOOL TOOL=0, then G28 Z."'
         _INDX_HOME_Z_FAIL
     {% else %}
         _INDX_HOME_Z_PROBE

--- a/macros/homing.cfg
+++ b/macros/homing.cfg
@@ -101,22 +101,18 @@ gcode:
     {% endif %}
 
 [gcode_macro _INDX_HOME_VERIFY]
-description: Inner - settle and read load-cell seat, then call AFTER_SOFT or AFTER_HARD
+description: Inner - settle and read load-cell seat (does not dispatch; caller runs AFTER_SOFT / AFTER_HARD)
 variable_last_ok: -1
 variable_last_force_g: 0.0
 variable_settle_ms: 800
-variable_next_hard: 0
 gcode:
-    {% set nxt_hard = 1 if params.NEXT|default("soft") == "hard" else 0 %}
-    SET_GCODE_VARIABLE MACRO=_INDX_HOME_VERIFY VARIABLE=next_hard VALUE={nxt_hard}
     M400
     G4 P{printer["gcode_macro _INDX_HOME_VERIFY"].settle_ms|int}
     _INDX_HOME_VERIFY_READ
 
 [gcode_macro _INDX_HOME_VERIFY_READ]
-description: Inner - fail closed if the load cell is missing or uncalibrated; else continue
+description: Inner - fail closed if the load cell is missing or uncalibrated; else set last_ok
 gcode:
-    {% set v = printer["gcode_macro _INDX_HOME_VERIFY"] %}
     {% set min_g = printer["gcode_macro TOOL_POSITIONS"].home_min_force_g|default(800.0)|float %}
     {% set ns = namespace(ok=0, force=0.0, err="") %}
 
@@ -141,10 +137,6 @@ gcode:
     {% if ns.err %}
         SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z_FAIL VARIABLE=msg VALUE='"{ns.err}"'
         _INDX_HOME_Z_FAIL
-    {% elif v.next_hard|int %}
-        _INDX_HOME_Z_AFTER_HARD
-    {% else %}
-        _INDX_HOME_Z_AFTER_SOFT
     {% endif %}
 
 [gcode_macro _INDX_HOME_Z]
@@ -165,7 +157,10 @@ gcode:
             SET_KINEMATIC_POSITION SET_HOMED=Z
             SET_GCODE_VARIABLE MACRO=_INDX_HOME_Z VARIABLE=z_faked VALUE=1
         {% endif %}
-        _INDX_HOME_VERIFY NEXT=soft
+        # AFTER_SOFT is a sibling, not a child of VERIFY. Empty-head G28 picks T0
+        # then verifies again; Klipper/Kalico refuse a nested _INDX_HOME_VERIFY.
+        _INDX_HOME_VERIFY
+        _INDX_HOME_Z_AFTER_SOFT
     {% endif %}
 
 [gcode_macro _INDX_HOME_Z_AFTER_SOFT]
@@ -191,7 +186,8 @@ gcode:
             SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=1
             CHANGE_TOOL TOOL=0
             SET_GCODE_VARIABLE MACRO=_TOOLCHANGE_VARS VARIABLE=homing_busy VALUE=0
-            _INDX_HOME_VERIFY NEXT=hard
+            _INDX_HOME_VERIFY
+            _INDX_HOME_Z_AFTER_HARD
         {% endif %}
     {% else %}
         {% set svv = printer.save_variables.variables %}


### PR DESCRIPTION
G28 with no tool seated (and Z already homed) picks T0, then `_INDX_HOME_VERIFY` calls itself before the first call has returned. Kalico raises `Macro _INDX_HOME_VERIFY called recursively` after pickup succeeds. That is #69.

The second seat check now runs after the first verify has finished. Z-home errors also say what to do next; an uncalibrated cell points at the Load cell calibration section in indx/README.

Fixes #69